### PR TITLE
feat(netrun-sim): implement undo_action for reversing NetSim state ch…

### DIFF
--- a/UNDO_FEATURE_PLAN.md
+++ b/UNDO_FEATURE_PLAN.md
@@ -1,0 +1,634 @@
+# Undo NetAction Feature Plan
+
+## Executive Summary
+
+This document outlines the design and implementation plan for adding undo functionality to the `netrun-sim` library. The feature will allow users to reverse NetActions by passing undo information back to the library.
+
+**Key Design Decisions:**
+1. Replace `RunNetUntilBlocked` with `RunStep` (single-step execution)
+2. `NetSim` does **not** maintain any history
+3. `undo_action()` takes undo data returned from the original action
+
+---
+
+## Part 1: Replace `RunNetUntilBlocked` with `RunStep`
+
+### Rationale
+
+`RunNetUntilBlocked` is problematic for undo because:
+1. It runs an unbounded loop, producing arbitrarily many events
+2. The internal state changes are compound and hard to reverse atomically
+3. Users lose fine-grained control over execution
+
+`RunStep` provides:
+1. Single-step execution (one "phase" of work)
+2. Clear return value indicating whether progress was made
+3. Easy undo (reverse a single step's events)
+
+### New Action Design
+
+```rust
+/// An action that can be performed on the network.
+#[derive(Debug, Clone)]
+pub enum NetAction {
+    /// Execute one step of automatic packet flow.
+    /// Returns whether any progress was made (i.e., not blocked).
+    RunStep,
+
+    // ... all other actions unchanged ...
+    CreatePacket(Option<EpochID>),
+    ConsumePacket(PacketID),
+    DestroyPacket(PacketID),
+    StartEpoch(EpochID),
+    FinishEpoch(EpochID),
+    CancelEpoch(EpochID),
+    CreateEpoch(NodeName, Salvo),
+    LoadPacketIntoOutputPort(PacketID, PortName),
+    SendOutputSalvo(EpochID, SalvoConditionName),
+    TransportPacketToLocation(PacketID, PacketLocation),
+}
+```
+
+### RunStep Semantics
+
+A single step performs **one full iteration** of the flow loop:
+
+1. **Phase 1: Move all movable packets from edges to input ports**
+   - For each edge with packets, if the destination input port has capacity, move the first packet (FIFO)
+   - Multiple packets can move in this phase (one per edge)
+
+2. **Phase 2: Trigger all satisfied input salvo conditions**
+   - For each node with packets at input ports, check salvo conditions
+   - First satisfied condition per node triggers, creating an epoch
+   - Multiple epochs can be created in this phase (one per node)
+
+If neither phase makes progress (no packets moved, no salvos triggered), the network is "blocked" and `RunStep` returns indicating no progress.
+
+**Rationale:** This matches one iteration of the current `run_until_blocked` loop. Finer granularity (single packet per step) would be inefficient due to action call overhead. Undo still works because all events are recorded and can be reversed in order.
+
+```rust
+/// Data returned by a successful network action.
+#[derive(Debug, Clone)]
+pub enum NetActionResponseData {
+    /// Result of RunStep: whether progress was made
+    StepResult { made_progress: bool },
+
+    // ... existing variants ...
+    Packet(PacketID),
+    CreatedEpoch(Epoch),
+    StartedEpoch(Epoch),
+    FinishedEpoch(Epoch),
+    CancelledEpoch(Epoch, Vec<PacketID>),
+    None,
+}
+```
+
+### Helper Method
+
+```rust
+impl NetSim {
+    /// Check if the network is blocked (no progress can be made).
+    ///
+    /// Returns true if:
+    /// - No packets can move from edges to input ports (all destinations full or no packets on edges)
+    /// - No input salvo conditions can be triggered
+    pub fn is_blocked(&self) -> bool;
+}
+```
+
+### Migration Path
+
+Users currently calling `RunNetUntilBlocked` can migrate to:
+
+```rust
+// Old code
+net.do_action(&NetAction::RunNetUntilBlocked);
+
+// New code - equivalent behavior
+while !net.is_blocked() {
+    net.do_action(&NetAction::RunStep);
+}
+
+// Or with response checking (doesn't need is_blocked)
+loop {
+    match net.do_action(&NetAction::RunStep) {
+        NetActionResponse::Success(NetActionResponseData::StepResult { made_progress }, _) => {
+            if !made_progress { break; }
+        }
+        _ => break,
+    }
+}
+```
+
+Since `RunStep` does one full loop iteration, the migration is straightforward - just loop until blocked.
+
+---
+
+## Part 2: Undo Design Without History
+
+### Core Principle
+
+The `NetSim` maintains **no history**. Instead:
+1. `do_action()` returns all information needed for undo
+2. `undo_action()` takes that information to reverse the action
+3. The caller is responsible for storing undo data if needed
+
+### Analysis: Is `NetAction` + `Vec<NetEvent>` Sufficient?
+
+**Question:** Can we undo using just the original `NetAction` and the `Vec<NetEvent>` that were produced?
+
+**Answer:** Almost, but **events need enhancement** for some actions.
+
+#### Actions Where Events ARE Sufficient
+
+| Action | Why Events Work |
+|--------|-----------------|
+| `CreatePacket` | `PacketCreated(time, id)` has packet ID to remove |
+| `StartEpoch` | `EpochStarted(time, id)` - just revert state to Startable |
+| `CreateEpoch` | `EpochCreated` + `PacketMoved(from, to)` - reverse moves, remove epoch |
+| `LoadPacketIntoOutputPort` | `PacketMoved(from, to)` - reverse the move |
+| `SendOutputSalvo` | `PacketMoved(from, to)` per packet - reverse moves, pop out_salvos |
+| `TransportPacketToLocation` | `PacketMoved(from, to)` - reverse the move |
+| `RunStep` | Same events as above - all reversible |
+
+#### Actions Where Events Are NOT Sufficient
+
+| Action | What's Missing | Solution |
+|--------|---------------|----------|
+| `ConsumePacket` | `PacketConsumed(time, id)` lacks **previous location** | Enhance event |
+| `DestroyPacket` | `PacketDestroyed(time, id)` lacks **previous location** | Enhance event |
+| `FinishEpoch` | Epoch is **removed** from `_epochs` - need full epoch data | Use response data |
+| `CancelEpoch` | Epoch removed + packets destroyed - need packet locations | Enhance events + use response |
+
+### Solution: Enhanced Events + Response Data
+
+#### Option A: Enhance Events Only (Recommended)
+
+Modify events to include all information needed for perfect undo:
+
+```rust
+pub enum NetEvent {
+    // Unchanged
+    PacketCreated(EventUTC, PacketID),
+    EpochCreated(EventUTC, EpochID),
+    EpochStarted(EventUTC, EpochID),
+    InputSalvoTriggered(EventUTC, EpochID, SalvoConditionName),
+    OutputSalvoTriggered(EventUTC, EpochID, SalvoConditionName),
+
+    // Enhanced with location for undo
+    PacketConsumed(EventUTC, PacketID, PacketLocation),  // +location
+    PacketDestroyed(EventUTC, PacketID, PacketLocation), // +location
+
+    // Enhanced with full Epoch for undo
+    EpochFinished(EventUTC, Epoch),   // EpochID → Epoch
+    EpochCancelled(EventUTC, Epoch),  // EpochID → Epoch
+
+    // Enhanced with source index for perfect IndexSet restoration
+    PacketMoved(EventUTC, PacketID, PacketLocation, PacketLocation, usize),  // +from_index
+}
+```
+
+With these changes, `undo_action(action: &NetAction, events: &[NetEvent])` has all needed information for **perfect state restoration**.
+
+**Pros:**
+- Single source of truth (events contain everything)
+- Clean API: `undo_action(&action, &events)`
+- Events become more informative for debugging/logging
+
+**Cons:**
+- Events become larger (Epoch can be significant)
+- Breaking change to event format
+
+#### Option B: Separate Undo Data
+
+Keep events minimal, return separate undo data:
+
+```rust
+/// Data needed to undo an action (returned alongside events)
+#[derive(Debug, Clone)]
+pub enum NetActionUndoData {
+    /// No special data needed (can undo from events alone)
+    None,
+    /// Location of consumed/destroyed packet
+    PacketLocation(PacketLocation),
+    /// Epoch that was finished/cancelled
+    Epoch(Epoch),
+    /// Epoch + packet locations for CancelEpoch
+    CancelledEpoch { epoch: Epoch, packet_locations: Vec<(PacketID, PacketLocation)> },
+}
+
+pub enum NetActionResponse {
+    Success(NetActionResponseData, Vec<NetEvent>, NetActionUndoData),  // Added undo data
+    Error(NetActionError),
+}
+```
+
+**Pros:**
+- Events stay minimal
+- Clear separation of concerns
+
+**Cons:**
+- Redundant data structures
+- More complex API
+
+### Recommendation: Option A (Enhanced Events)
+
+Events are already the "record of what happened" - they should contain enough information to understand (and reverse) what happened. Enhanced events are more useful for debugging, logging, and replay regardless of undo.
+
+### Undo Function Signature
+
+```rust
+impl NetSim {
+    /// Undo a previously executed action.
+    ///
+    /// Takes the original action and the events it produced.
+    /// Returns Ok(()) on success, or an error if undo is not possible.
+    ///
+    /// # Restrictions
+    /// - Actions must be undone in reverse order (LIFO)
+    /// - Some state may have changed since the action (undo may fail)
+    ///
+    /// # Example
+    /// ```
+    /// let response = net.do_action(&NetAction::CreatePacket(None));
+    /// if let NetActionResponse::Success(_, events) = response {
+    ///     // Later, to undo:
+    ///     net.undo_action(&NetAction::CreatePacket(None), &events)?;
+    /// }
+    /// ```
+    pub fn undo_action(&mut self, action: &NetAction, events: &[NetEvent]) -> Result<(), UndoError>;
+}
+
+#[derive(Debug, Clone)]
+pub enum UndoError {
+    /// Cannot undo because state has changed
+    StateChanged(String),
+    /// Cannot undo this action type
+    NotUndoable(String),
+    /// Internal error during undo
+    InternalError(String),
+}
+```
+
+---
+
+## Part 3: Undo Implementation Per Action
+
+### RunStep
+
+**Forward:** One iteration of flow loop - move all movable packets, trigger all satisfied salvos
+**Events:** Multiple `PacketMoved` (phase 1) + multiple (`InputSalvoTriggered` + `EpochCreated` + `PacketMoved`) sequences (phase 2)
+
+**Undo:**
+1. Process events in **reverse** order
+2. For each `PacketMoved(_, id, from, to, from_index)`: Remove packet from `to`, insert back into `from` at `from_index` using `shift_insert`
+3. For each `EpochCreated(_, epoch_id)`: Remove epoch from `_epochs`, `_startable_epochs`, `_node_to_epochs`, and remove location entries
+4. Ignore `InputSalvoTriggered` (informational only)
+
+Note: Multiple events are reversed in LIFO order, and `from_index` ensures perfect IndexSet ordering restoration.
+
+### CreatePacket
+
+**Forward:** Create packet at location
+**Events:** `PacketCreated(_, packet_id)`
+
+**Undo:** Remove packet by ID
+
+### ConsumePacket / DestroyPacket
+
+**Forward:** Remove packet from network
+**Events (enhanced):** `PacketConsumed(_, packet_id, location)` or `PacketDestroyed(_, packet_id, location)`
+
+**Undo:** Recreate packet at the stored location
+
+### StartEpoch
+
+**Forward:** Change epoch state Startable → Running, remove from `_startable_epochs`
+**Events:** `EpochStarted(_, epoch_id)`
+
+**Undo:** Change state back to Startable, add to `_startable_epochs`
+
+### FinishEpoch
+
+**Forward:** Remove epoch from `_epochs`, clean up location entries
+**Events (enhanced):** `EpochFinished(_, epoch)` (full Epoch struct)
+
+**Undo:**
+1. Restore epoch to `_epochs` with state = Running
+2. Recreate location entries (`Node(epoch_id)` and `OutputPort(epoch_id, port)` for each out port)
+
+### CancelEpoch
+
+**Forward:** Destroy all packets in epoch, remove epoch
+**Events (enhanced):** `PacketDestroyed(_, packet_id, location)` per packet, then `EpochCancelled(_, epoch)`
+
+**Undo:**
+1. Restore epoch to `_epochs` (state from the Epoch in event)
+2. Recreate location entries
+3. Recreate each packet at its stored location
+
+### CreateEpoch
+
+**Forward:** Create epoch, move packets from input ports into epoch
+**Events:** `EpochCreated(_, epoch_id)` + `PacketMoved(_, packet_id, from, to, from_index)` per packet
+
+**Undo:**
+1. Move packets back using `shift_insert` at `from_index` (reverse each `PacketMoved`)
+2. Remove epoch from all indices
+3. Remove location entries for the epoch
+
+### LoadPacketIntoOutputPort
+
+**Forward:** Move packet from Node location to OutputPort location
+**Events:** `PacketMoved(_, packet_id, from, to, from_index)`
+
+**Undo:** Remove from `to`, insert back into `from` at `from_index`
+
+### SendOutputSalvo
+
+**Forward:** Move packets to edges, add salvo to `epoch.out_salvos`
+**Events:** `PacketMoved(_, packet_id, from, to, from_index)` per packet, `OutputSalvoTriggered(_, epoch_id, condition)`
+
+**Undo:**
+1. Move packets back using `shift_insert` at `from_index` (reverse each `PacketMoved`)
+2. Pop last entry from `epoch.out_salvos`
+
+### TransportPacketToLocation
+
+**Forward:** Move packet to new location
+**Events:** `PacketMoved(_, packet_id, from, to, from_index)`
+
+**Undo:** Remove from `to`, insert back into `from` at `from_index`
+
+---
+
+## Part 4: Implementation Plan
+
+### Phase 1: Replace RunNetUntilBlocked with RunStep
+
+1. Add `RunStep` variant to `NetAction`
+2. Implement `run_step()` method (single iteration of current loop)
+3. Add `is_blocked()` helper method
+4. Update `NetActionResponseData` to include `StepResult { made_progress: bool }`
+5. Deprecate/remove `RunNetUntilBlocked`
+6. Update tests
+
+### Phase 2: Enhance Events
+
+1. Modify `PacketConsumed` to include location: `PacketConsumed(EventUTC, PacketID, PacketLocation)`
+2. Modify `PacketDestroyed` to include location: `PacketDestroyed(EventUTC, PacketID, PacketLocation)`
+3. Modify `EpochFinished` to include epoch: `EpochFinished(EventUTC, Epoch)`
+4. Modify `EpochCancelled` to include epoch: `EpochCancelled(EventUTC, Epoch)`
+5. Modify `PacketMoved` to include source index: `PacketMoved(EventUTC, PacketID, PacketLocation, PacketLocation, usize)`
+6. Update all code that produces these events (capture index before removal)
+7. Update all code that consumes/matches on these events
+8. Update tests
+
+### Phase 3: Implement Undo
+
+1. Add `UndoError` enum
+2. Implement `undo_action()` method
+3. Implement undo logic for each action type:
+   - Simple: `CreatePacket`, `StartEpoch`, `LoadPacketIntoOutputPort`, `TransportPacketToLocation`
+   - Medium: `ConsumePacket`, `DestroyPacket`, `CreateEpoch`, `SendOutputSalvo`
+   - Complex: `FinishEpoch`, `CancelEpoch`, `RunStep`
+4. Add comprehensive tests
+
+### Phase 4: Python Bindings
+
+1. Expose `RunStep` action
+2. Expose `is_blocked()` method
+3. Expose `undo_action()` method
+4. Update type stubs
+5. Add Python tests
+
+---
+
+## Part 5: Edge Cases and Considerations
+
+### IndexSet Ordering
+
+The `_packets_by_location` uses `IndexSet` which maintains insertion order (FIFO). This ordering matters for salvo condition evaluation and packet flow.
+
+**Solution:** Store the source index in `PacketMoved` events. On undo, use `IndexSet::shift_insert` to restore the packet to its exact original position.
+
+```rust
+// Enhanced PacketMoved event
+PacketMoved(EventUTC, PacketID, PacketLocation, PacketLocation, usize)
+//          time      packet_id from            to              from_index
+
+// Undo implementation
+fn undo_packet_move(&mut self, packet_id: PacketID, from: &PacketLocation, to: &PacketLocation, from_index: usize) {
+    // Remove from destination
+    self._packets_by_location
+        .get_mut(to)
+        .unwrap()
+        .shift_remove(&packet_id);
+
+    // Insert back into source at original index
+    self._packets_by_location
+        .get_mut(from)
+        .unwrap()
+        .shift_insert(from_index, packet_id);
+
+    // Update packet's location field
+    self._packets.get_mut(&packet_id).unwrap().location = from.clone();
+}
+```
+
+This guarantees **perfect state restoration** - packet ordering is preserved exactly.
+
+### Undo Validation
+
+Undo can fail if state has changed since the original action:
+
+```rust
+// Create packet P1
+let resp1 = net.do_action(&NetAction::CreatePacket(None));
+
+// Consume packet P1
+net.do_action(&NetAction::ConsumePacket(p1_id));
+
+// Try to undo creation - FAILS because P1 no longer exists
+net.undo_action(&NetAction::CreatePacket(None), &events1); // Error: packet not found
+```
+
+**Behavior:** `undo_action` validates preconditions and returns `UndoError::StateChanged` if undo is not possible.
+
+### Undo Does Not Produce Events
+
+Undo operations do **not** emit events. Rationale:
+- Undo is a meta-operation restoring previous state
+- Emitting events would create confusing audit trails (e.g., `PacketCreated` during undo of `ConsumePacket`)
+- If event logging is needed for undo, the caller can track it externally
+
+### Thread Safety
+
+`NetSim` is not thread-safe. Undo assumes single-threaded access. The caller is responsible for synchronization if needed.
+
+---
+
+## Part 6: API Examples
+
+### Basic Undo Flow
+
+```rust
+let mut net = NetSim::new(graph);
+
+// Perform action
+let action = NetAction::CreatePacket(None);
+let response = net.do_action(&action);
+let (packet_id, events) = match response {
+    NetActionResponse::Success(NetActionResponseData::Packet(id), events) => (id, events),
+    _ => panic!("unexpected"),
+};
+
+// ... later, undo the action ...
+net.undo_action(&action, &events)?;
+// Packet no longer exists
+assert!(net.get_packet(&packet_id).is_none());
+```
+
+### RunStep Loop with Undo Stack
+
+```rust
+let mut net = NetSim::new(graph);
+let mut undo_stack: Vec<(NetAction, Vec<NetEvent>)> = Vec::new();
+
+// Run network, collecting undo info for each step
+while !net.is_blocked() {
+    let action = NetAction::RunStep;
+    if let NetActionResponse::Success(NetActionResponseData::StepResult { made_progress: true }, events) =
+        net.do_action(&action)
+    {
+        // Each step may produce many events (multiple packet moves + epoch creations)
+        undo_stack.push((action, events));
+    }
+}
+
+// Undo last 3 steps (each step may have moved multiple packets / created multiple epochs)
+for _ in 0..3 {
+    if let Some((action, events)) = undo_stack.pop() {
+        net.undo_action(&action, &events)?;
+    }
+}
+```
+
+### Python Usage
+
+```python
+from netrun_sim import NetSim, NetAction, NetActionResponse
+
+net = NetSim(graph)
+
+# Check if blocked
+if not net.is_blocked():
+    response = net.do_action(NetAction.RunStep())
+
+# Undo
+action = NetAction.CreatePacket(None)
+response = net.do_action(action)
+if response.is_success():
+    events = response.events
+    net.undo_action(action, events)
+```
+
+---
+
+## Summary
+
+| Aspect | Decision |
+|--------|----------|
+| Replace `RunNetUntilBlocked` | Yes - new `RunStep` action |
+| History in NetSim | No - caller manages undo data |
+| Undo data format | Enhanced events (location, epoch, from_index) |
+| Undo signature | `undo_action(&action, &events) -> Result<(), UndoError>` |
+| IndexSet ordering | Perfect restoration via `shift_insert` with stored `from_index` |
+| Undo events | None emitted |
+
+**Event Enhancements:**
+- `PacketConsumed`: +location
+- `PacketDestroyed`: +location
+- `EpochFinished`: EpochID → Epoch
+- `EpochCancelled`: EpochID → Epoch
+- `PacketMoved`: +from_index
+
+**Implementation Order:**
+1. RunStep + is_blocked()
+2. Enhance events
+3. Implement undo_action
+4. Python bindings
+
+**Estimated Scope:** ~600-800 lines of new Rust code, ~150 lines of Python bindings.
+
+---
+
+## Implementation Status: COMPLETED ✓
+
+The undo feature has been fully implemented on branch `feat/undo-action`.
+
+### Completed Items:
+
+1. **Phase 1: RunStep + is_blocked()** ✓
+   - Replaced `RunNetUntilBlocked` with `RunStep`
+   - Implemented `run_step()` method
+   - Added `is_blocked()` helper method
+   - Added `run_until_blocked()` convenience method for easy migration
+   - Updated `NetActionResponseData` with `StepResult { made_progress: bool }`
+
+2. **Phase 2: Enhanced Events** ✓
+   - `PacketConsumed(EventUTC, PacketID, PacketLocation)` - added location
+   - `PacketDestroyed(EventUTC, PacketID, PacketLocation)` - added location
+   - `EpochFinished(EventUTC, Epoch)` - changed from EpochID to full Epoch
+   - `EpochCancelled(EventUTC, Epoch)` - changed from EpochID to full Epoch
+   - `PacketMoved(EventUTC, PacketID, PacketLocation, PacketLocation, usize)` - added from_index
+   - `SendOutputSalvo` now emits `OutputSalvoTriggered` event
+
+3. **Phase 3: undo_action() Implementation** ✓
+   - Added `UndoError` enum with variants: `StateMismatch`, `NotFound`, `NotUndoable`, `InternalError`
+   - Implemented `undo_action(&mut self, action: &NetAction, events: &[NetEvent]) -> Result<(), UndoError>`
+   - Undo handlers for all event types:
+     - `undo_packet_created` - removes packet
+     - `undo_packet_consumed` / `undo_packet_destroyed` - recreates packet at stored location
+     - `undo_epoch_created` - removes epoch from all indices
+     - `undo_epoch_started` - reverts state to Startable
+     - `undo_epoch_finished` / `undo_epoch_cancelled` - restores epoch from event
+     - `undo_packet_moved` - uses `shift_insert` for perfect ordering restoration
+     - `undo_output_salvo_triggered` - pops from `out_salvos`
+
+4. **Phase 4: Tests** ✓
+   - `test_undo_create_packet`
+   - `test_undo_consume_packet`
+   - `test_undo_start_epoch`
+   - `test_undo_finish_epoch`
+   - `test_undo_transport_packet_to_location`
+   - `test_undo_run_step`
+   - `test_undo_preserves_packet_ordering`
+   - `test_undo_cancel_epoch`
+   - `test_undo_send_output_salvo`
+   - `test_undo_create_epoch`
+
+5. **Phase 5: Python Bindings** ✓
+   - Updated `NetAction` with `run_step()` (replaces `run_net_until_blocked()`)
+   - Added `is_blocked()` method to `NetSim`
+   - Added `run_until_blocked()` method to `NetSim`
+   - Added `undo_action()` method to `NetSim`
+   - Updated `NetEvent` with new fields (location, epoch, from_index)
+   - Added `UndoError` exception hierarchy
+   - Updated `NetActionResponseData` with `StepResult`
+
+### Test Results:
+- 44 unit tests ✓
+- 21 graph_api tests ✓
+- 26 net_api tests ✓
+- 9 workflow tests ✓
+- Python bindings compile successfully ✓
+
+### Files Modified:
+- `netrun-sim/core/src/net.rs` - main implementation
+- `netrun-sim/core/src/net_tests.rs` - undo tests
+- `netrun-sim/core/tests/workflow.rs` - updated for new API
+- `netrun-sim/core/tests/net_api.rs` - updated for new API
+- `netrun-sim/core/examples/*.rs` - updated for new API
+- `netrun-sim/python/src/net.rs` - Python bindings
+- `netrun-sim/python/src/errors.rs` - UndoError exceptions

--- a/netrun-sim/core/examples/diamond_flow.rs
+++ b/netrun-sim/core/examples/diamond_flow.rs
@@ -51,7 +51,7 @@ fn main() {
     println!("Placed packet2 on edge A -> C");
 
     // Run network - packets move to B and C, triggering epochs
-    net.do_action(&NetAction::RunNetUntilBlocked);
+    net.run_until_blocked();
 
     let startable = net.get_startable_epochs();
     println!(
@@ -94,7 +94,7 @@ fn main() {
     }
 
     // Run network - packets move from B->D and C->D edges to D's input ports
-    net.do_action(&NetAction::RunNetUntilBlocked);
+    net.run_until_blocked();
 
     // Check D's input ports
     let d_in1 = PacketLocation::InputPort("D".to_string(), "in1".to_string());

--- a/netrun-sim/core/examples/linear_flow.rs
+++ b/netrun-sim/core/examples/linear_flow.rs
@@ -53,7 +53,7 @@ fn main() {
     println!("Placed packet on edge A -> B");
 
     // Run the network - packet moves to B's input port and triggers an epoch
-    net.do_action(&NetAction::RunNetUntilBlocked);
+    net.run_until_blocked();
     println!("Ran network until blocked");
 
     // Check for startable epochs
@@ -100,7 +100,7 @@ fn main() {
                 println!("Finished epoch");
 
                 // Run the network again - packet moves to C
-                net.do_action(&NetAction::RunNetUntilBlocked);
+                net.run_until_blocked();
                 println!("Ran network until blocked again");
 
                 // Check for new startable epochs at C

--- a/netrun-sim/core/src/net_tests.rs
+++ b/netrun-sim/core/src/net_tests.rs
@@ -1,5 +1,152 @@
 use super::*;
 use crate::test_fixtures::*;
+use std::collections::HashMap;
+
+// ========== State Snapshot Helpers for Exact Undo Verification ==========
+
+/// A complete snapshot of the NetSim state for comparison.
+#[derive(Debug, Clone, PartialEq)]
+struct NetSimSnapshot {
+    /// All packets with their IDs and locations
+    packets: HashMap<PacketID, PacketLocation>,
+    /// Packets at each location, in order (for IndexSet ordering verification)
+    packets_by_location: HashMap<PacketLocation, Vec<PacketID>>,
+    /// All epochs with their full state
+    epochs: HashMap<EpochID, EpochSnapshot>,
+    /// Set of startable epoch IDs
+    startable_epochs: Vec<EpochID>,
+    /// Node to epochs mapping
+    node_to_epochs: HashMap<String, Vec<EpochID>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct EpochSnapshot {
+    id: EpochID,
+    node_name: String,
+    state: EpochState,
+    in_salvo_condition: String,
+    in_salvo_packets: Vec<(String, PacketID)>,
+    out_salvos_count: usize,
+}
+
+impl NetSimSnapshot {
+    /// Capture the complete state of a NetSim.
+    fn capture(net: &NetSim) -> Self {
+        // Capture packets
+        let packets: HashMap<PacketID, PacketLocation> = net
+            ._packets
+            .iter()
+            .map(|(id, p)| (*id, p.location.clone()))
+            .collect();
+
+        // Capture packets_by_location with ordering
+        let packets_by_location: HashMap<PacketLocation, Vec<PacketID>> = net
+            ._packets_by_location
+            .iter()
+            .map(|(loc, ids)| (loc.clone(), ids.iter().cloned().collect()))
+            .collect();
+
+        // Capture epochs
+        let epochs: HashMap<EpochID, EpochSnapshot> = net
+            ._epochs
+            .iter()
+            .map(|(id, e)| {
+                (
+                    *id,
+                    EpochSnapshot {
+                        id: e.id,
+                        node_name: e.node_name.clone(),
+                        state: e.state.clone(),
+                        in_salvo_condition: e.in_salvo.salvo_condition.clone(),
+                        in_salvo_packets: e.in_salvo.packets.clone(),
+                        out_salvos_count: e.out_salvos.len(),
+                    },
+                )
+            })
+            .collect();
+
+        // Capture startable epochs (sorted for deterministic comparison)
+        let mut startable_epochs: Vec<EpochID> = net._startable_epochs.iter().cloned().collect();
+        startable_epochs.sort();
+
+        // Capture node_to_epochs
+        let node_to_epochs: HashMap<String, Vec<EpochID>> = net
+            ._node_to_epochs
+            .iter()
+            .map(|(node, ids)| (node.clone(), ids.clone()))
+            .collect();
+
+        NetSimSnapshot {
+            packets,
+            packets_by_location,
+            epochs,
+            startable_epochs,
+            node_to_epochs,
+        }
+    }
+
+    /// Compare two snapshots and return a description of differences.
+    fn diff(&self, other: &NetSimSnapshot) -> Vec<String> {
+        let mut diffs = Vec::new();
+
+        // Compare packets
+        if self.packets != other.packets {
+            diffs.push(format!(
+                "Packets differ:\n  before: {:?}\n  after:  {:?}",
+                self.packets, other.packets
+            ));
+        }
+
+        // Compare packets_by_location (including ordering)
+        if self.packets_by_location != other.packets_by_location {
+            for (loc, before_ids) in &self.packets_by_location {
+                match other.packets_by_location.get(loc) {
+                    Some(after_ids) if before_ids != after_ids => {
+                        diffs.push(format!(
+                            "Packet order at {:?} differs:\n  before: {:?}\n  after:  {:?}",
+                            loc, before_ids, after_ids
+                        ));
+                    }
+                    None => {
+                        diffs.push(format!("Location {:?} missing after undo", loc));
+                    }
+                    _ => {}
+                }
+            }
+            for loc in other.packets_by_location.keys() {
+                if !self.packets_by_location.contains_key(loc) {
+                    diffs.push(format!("Extra location {:?} after undo", loc));
+                }
+            }
+        }
+
+        // Compare epochs
+        if self.epochs != other.epochs {
+            diffs.push(format!(
+                "Epochs differ:\n  before: {:?}\n  after:  {:?}",
+                self.epochs, other.epochs
+            ));
+        }
+
+        // Compare startable_epochs
+        if self.startable_epochs != other.startable_epochs {
+            diffs.push(format!(
+                "Startable epochs differ:\n  before: {:?}\n  after:  {:?}",
+                self.startable_epochs, other.startable_epochs
+            ));
+        }
+
+        // Compare node_to_epochs
+        if self.node_to_epochs != other.node_to_epochs {
+            diffs.push(format!(
+                "Node to epochs differ:\n  before: {:?}\n  after:  {:?}",
+                self.node_to_epochs, other.node_to_epochs
+            ));
+        }
+
+        diffs
+    }
+}
 
 // Helper to extract packet ID from create response
 fn get_packet_id(response: &NetActionResponse) -> PacketID {
@@ -103,7 +250,7 @@ fn test_epoch_lifecycle_via_run_until_blocked() {
         .insert(packet_id.clone());
 
     // Run until blocked - packet should move to input port and trigger epoch
-    net.do_action(&NetAction::RunNetUntilBlocked);
+    net.run_until_blocked();
 
     // Should have one startable epoch
     let startable = net.startable_epoch_ids();
@@ -294,7 +441,7 @@ fn test_run_until_blocked_moves_packet_to_input_port() {
         .insert(packet_id.clone());
 
     // Run until blocked
-    net.do_action(&NetAction::RunNetUntilBlocked);
+    net.run_until_blocked();
 
     // Packet should have triggered an epoch (moved into node)
     assert_eq!(net.startable_epoch_ids().len(), 1);
@@ -359,7 +506,7 @@ fn test_run_until_blocked_respects_port_capacity() {
     }
 
     // Run until blocked - only first packet should move (capacity = 1)
-    net.do_action(&NetAction::RunNetUntilBlocked);
+    net.run_until_blocked();
 
     // No epochs created (no salvo conditions), one packet at input port, one still on edge
     assert_eq!(net.startable_epoch_ids().len(), 0);
@@ -407,20 +554,16 @@ fn test_fifo_packet_ordering() {
     }
 
     // Run - each packet triggers its own epoch (default salvo condition)
-    let response = net.do_action(&NetAction::RunNetUntilBlocked);
-
-    // Extract PacketMoved events to verify FIFO order
-    let events = match response {
-        NetActionResponse::Success(_, events) => events,
-        _ => panic!("Expected success response"),
-    };
+    let events = net.run_until_blocked();
 
     // Find the first PacketMoved event for each packet (when it moved from edge to input port)
     // The order of these events should match the FIFO order: packet1, packet2, packet3
     let packet_move_order: Vec<PacketID> = events
         .iter()
         .filter_map(|event| {
-            if let NetEvent::PacketMoved(_, packet_id, _, PacketLocation::InputPort(_, _)) = event {
+            if let NetEvent::PacketMoved(_, packet_id, _, PacketLocation::InputPort(_, _), _) =
+                event
+            {
                 Some(packet_id.clone())
             } else {
                 None
@@ -620,4 +763,964 @@ fn test_create_epoch_validates_packet_location() {
         response,
         NetActionResponse::Error(NetActionError::PacketNotAtInputPort { .. })
     ));
+}
+
+// ========== Undo Tests ==========
+
+#[test]
+fn test_undo_create_packet() {
+    let graph = linear_graph_3();
+    let mut net = NetSim::new(graph);
+
+    // Create a packet
+    let action = NetAction::CreatePacket(None);
+    let response = net.do_action(&action);
+    let (packet_id, events) = match response {
+        NetActionResponse::Success(NetActionResponseData::Packet(id), events) => (id, events),
+        _ => panic!("Expected Packet response"),
+    };
+
+    // Verify packet exists
+    assert!(net.get_packet(&packet_id).is_some());
+
+    // Undo the creation
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Verify packet no longer exists
+    assert!(net.get_packet(&packet_id).is_none());
+    assert_eq!(net.packet_count_at(&PacketLocation::OutsideNet), 0);
+}
+
+#[test]
+fn test_undo_consume_packet() {
+    let graph = linear_graph_3();
+    let mut net = NetSim::new(graph);
+
+    // Create a packet
+    let packet_id = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+
+    // Consume the packet
+    let action = NetAction::ConsumePacket(packet_id);
+    let events = match net.do_action(&action) {
+        NetActionResponse::Success(_, events) => events,
+        _ => panic!("Expected success"),
+    };
+
+    // Verify packet is gone
+    assert!(net.get_packet(&packet_id).is_none());
+
+    // Undo the consumption
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Verify packet is restored at original location
+    assert!(net.get_packet(&packet_id).is_some());
+    assert_eq!(net.get_packet(&packet_id).unwrap().location, PacketLocation::OutsideNet);
+}
+
+#[test]
+fn test_undo_start_epoch() {
+    let graph = linear_graph_3();
+    let mut net = NetSim::new(graph);
+
+    // Create packet and place at input port
+    let packet_id = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+    let input_port_loc = PacketLocation::InputPort("B".to_string(), "in".to_string());
+    net._packets.get_mut(&packet_id).unwrap().location = input_port_loc.clone();
+    net._packets_by_location
+        .get_mut(&PacketLocation::OutsideNet)
+        .unwrap()
+        .shift_remove(&packet_id);
+    net._packets_by_location
+        .get_mut(&input_port_loc)
+        .unwrap()
+        .insert(packet_id);
+
+    // Create epoch
+    let salvo = Salvo {
+        salvo_condition: "manual".to_string(),
+        packets: vec![("in".to_string(), packet_id)],
+    };
+    let epoch = get_created_epoch(&net.do_action(&NetAction::CreateEpoch("B".to_string(), salvo)));
+    let epoch_id = epoch.id;
+
+    // Start epoch
+    let action = NetAction::StartEpoch(epoch_id);
+    let events = match net.do_action(&action) {
+        NetActionResponse::Success(_, events) => events,
+        _ => panic!("Expected success"),
+    };
+
+    // Verify epoch is Running
+    assert!(matches!(net.get_epoch(&epoch_id).unwrap().state, EpochState::Running));
+    assert!(!net.get_startable_epochs().contains(&epoch_id));
+
+    // Undo the start
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Verify epoch is back to Startable
+    assert!(matches!(net.get_epoch(&epoch_id).unwrap().state, EpochState::Startable));
+    assert!(net.get_startable_epochs().contains(&epoch_id));
+}
+
+#[test]
+fn test_undo_finish_epoch() {
+    let graph = linear_graph_3();
+    let mut net = NetSim::new(graph);
+
+    // Create packet and place at input port
+    let packet_id = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+    let input_port_loc = PacketLocation::InputPort("B".to_string(), "in".to_string());
+    net._packets.get_mut(&packet_id).unwrap().location = input_port_loc.clone();
+    net._packets_by_location
+        .get_mut(&PacketLocation::OutsideNet)
+        .unwrap()
+        .shift_remove(&packet_id);
+    net._packets_by_location
+        .get_mut(&input_port_loc)
+        .unwrap()
+        .insert(packet_id);
+
+    // Create and start epoch
+    let salvo = Salvo {
+        salvo_condition: "manual".to_string(),
+        packets: vec![("in".to_string(), packet_id)],
+    };
+    let epoch = get_created_epoch(&net.do_action(&NetAction::CreateEpoch("B".to_string(), salvo)));
+    let epoch_id = epoch.id;
+    net.do_action(&NetAction::StartEpoch(epoch_id));
+
+    // Consume packet so epoch can be finished
+    net.do_action(&NetAction::ConsumePacket(packet_id));
+
+    // Finish epoch
+    let action = NetAction::FinishEpoch(epoch_id);
+    let events = match net.do_action(&action) {
+        NetActionResponse::Success(_, events) => events,
+        _ => panic!("Expected success"),
+    };
+
+    // Verify epoch is gone
+    assert!(net.get_epoch(&epoch_id).is_none());
+
+    // Undo the finish
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Verify epoch is restored and Running
+    assert!(net.get_epoch(&epoch_id).is_some());
+    assert!(matches!(net.get_epoch(&epoch_id).unwrap().state, EpochState::Running));
+}
+
+#[test]
+fn test_undo_transport_packet_to_location() {
+    let graph = linear_graph_3();
+    let mut net = NetSim::new(graph);
+
+    // Create a packet
+    let packet_id = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+
+    // Transport to input port
+    let input_port = PacketLocation::InputPort("B".to_string(), "in".to_string());
+    let action = NetAction::TransportPacketToLocation(packet_id, input_port.clone());
+    let events = match net.do_action(&action) {
+        NetActionResponse::Success(_, events) => events,
+        _ => panic!("Expected success"),
+    };
+
+    // Verify packet is at input port
+    assert_eq!(net.get_packet(&packet_id).unwrap().location, input_port);
+
+    // Undo the transport
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Verify packet is back at OutsideNet
+    assert_eq!(net.get_packet(&packet_id).unwrap().location, PacketLocation::OutsideNet);
+}
+
+#[test]
+fn test_undo_run_step() {
+    let graph = linear_graph_3();
+    let mut net = NetSim::new(graph);
+
+    // Create packet on edge A->B
+    let packet_id = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+    let edge_location = PacketLocation::Edge(Edge {
+        source: PortRef {
+            node_name: "A".to_string(),
+            port_type: PortType::Output,
+            port_name: "out".to_string(),
+        },
+        target: PortRef {
+            node_name: "B".to_string(),
+            port_type: PortType::Input,
+            port_name: "in".to_string(),
+        },
+    });
+    net._packets.get_mut(&packet_id).unwrap().location = edge_location.clone();
+    net._packets_by_location
+        .get_mut(&PacketLocation::OutsideNet)
+        .unwrap()
+        .shift_remove(&packet_id);
+    net._packets_by_location
+        .get_mut(&edge_location)
+        .unwrap()
+        .insert(packet_id);
+
+    // Run one step
+    let action = NetAction::RunStep;
+    let events = match net.do_action(&action) {
+        NetActionResponse::Success(_, events) => events,
+        _ => panic!("Expected success"),
+    };
+
+    // Verify an epoch was created
+    assert_eq!(net.get_startable_epochs().len(), 1);
+    let epoch_id = net.get_startable_epochs()[0];
+
+    // Undo the step
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Verify epoch is gone
+    assert!(net.get_epoch(&epoch_id).is_none());
+    assert_eq!(net.get_startable_epochs().len(), 0);
+
+    // Verify packet is back on edge
+    assert_eq!(net.get_packet(&packet_id).unwrap().location, edge_location);
+    assert_eq!(net.packet_count_at(&edge_location), 1);
+}
+
+#[test]
+fn test_undo_preserves_packet_ordering() {
+    // Test that undoing packet moves preserves FIFO ordering
+    let graph = linear_graph_3();
+    let mut net = NetSim::new(graph);
+
+    // Create 3 packets at OutsideNet
+    let packet1 = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+    let packet2 = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+    let packet3 = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+
+    // Verify initial order at OutsideNet
+    let initial_order = net.get_packets_at_location(&PacketLocation::OutsideNet);
+    assert_eq!(initial_order, vec![packet1, packet2, packet3]);
+
+    // Transport packet2 away
+    let input_port = PacketLocation::InputPort("B".to_string(), "in".to_string());
+    let action = NetAction::TransportPacketToLocation(packet2, input_port.clone());
+    let events = match net.do_action(&action) {
+        NetActionResponse::Success(_, events) => events,
+        _ => panic!("Expected success"),
+    };
+
+    // Verify packet2 is gone from OutsideNet
+    let after_move = net.get_packets_at_location(&PacketLocation::OutsideNet);
+    assert_eq!(after_move, vec![packet1, packet3]);
+
+    // Undo the transport
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Verify order is restored perfectly (packet2 back in its original position)
+    let restored_order = net.get_packets_at_location(&PacketLocation::OutsideNet);
+    assert_eq!(restored_order, vec![packet1, packet2, packet3],
+        "Packet order should be perfectly restored after undo");
+}
+
+#[test]
+fn test_undo_cancel_epoch() {
+    let graph = linear_graph_3();
+    let mut net = NetSim::new(graph);
+
+    // Create packet and place at input port
+    let packet_id = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+    let input_port_loc = PacketLocation::InputPort("B".to_string(), "in".to_string());
+    net._packets.get_mut(&packet_id).unwrap().location = input_port_loc.clone();
+    net._packets_by_location
+        .get_mut(&PacketLocation::OutsideNet)
+        .unwrap()
+        .shift_remove(&packet_id);
+    net._packets_by_location
+        .get_mut(&input_port_loc)
+        .unwrap()
+        .insert(packet_id);
+
+    // Create and start epoch
+    let salvo = Salvo {
+        salvo_condition: "manual".to_string(),
+        packets: vec![("in".to_string(), packet_id)],
+    };
+    let epoch = get_created_epoch(&net.do_action(&NetAction::CreateEpoch("B".to_string(), salvo)));
+    let epoch_id = epoch.id;
+    net.do_action(&NetAction::StartEpoch(epoch_id));
+
+    // Cancel epoch
+    let action = NetAction::CancelEpoch(epoch_id);
+    let events = match net.do_action(&action) {
+        NetActionResponse::Success(_, events) => events,
+        _ => panic!("Expected success"),
+    };
+
+    // Verify epoch and packet are gone
+    assert!(net.get_epoch(&epoch_id).is_none());
+    assert!(net.get_packet(&packet_id).is_none());
+
+    // Undo the cancel
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Verify epoch is restored
+    assert!(net.get_epoch(&epoch_id).is_some());
+    assert!(matches!(net.get_epoch(&epoch_id).unwrap().state, EpochState::Running));
+
+    // Verify packet is restored inside the epoch
+    assert!(net.get_packet(&packet_id).is_some());
+    assert_eq!(net.get_packet(&packet_id).unwrap().location, PacketLocation::Node(epoch_id));
+}
+
+#[test]
+fn test_undo_send_output_salvo() {
+    let graph = linear_graph_3();
+    let mut net = NetSim::new(graph);
+
+    // Create packet and place at input port of B
+    let packet_id = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+    let input_port_loc = PacketLocation::InputPort("B".to_string(), "in".to_string());
+    net._packets.get_mut(&packet_id).unwrap().location = input_port_loc.clone();
+    net._packets_by_location
+        .get_mut(&PacketLocation::OutsideNet)
+        .unwrap()
+        .shift_remove(&packet_id);
+    net._packets_by_location
+        .get_mut(&input_port_loc)
+        .unwrap()
+        .insert(packet_id);
+
+    // Create and start epoch
+    let salvo = Salvo {
+        salvo_condition: "manual".to_string(),
+        packets: vec![("in".to_string(), packet_id)],
+    };
+    let epoch = get_created_epoch(&net.do_action(&NetAction::CreateEpoch("B".to_string(), salvo)));
+    let epoch_id = epoch.id;
+    net.do_action(&NetAction::StartEpoch(epoch_id));
+
+    // Load packet into output port
+    net.do_action(&NetAction::LoadPacketIntoOutputPort(packet_id, "out".to_string()));
+
+    let output_port_loc = PacketLocation::OutputPort(epoch_id, "out".to_string());
+    assert_eq!(net.packet_count_at(&output_port_loc), 1);
+
+    // Send output salvo
+    let action = NetAction::SendOutputSalvo(epoch_id, "default".to_string());
+    let events = match net.do_action(&action) {
+        NetActionResponse::Success(_, events) => events,
+        _ => panic!("Expected success"),
+    };
+
+    // Verify packet is on edge
+    let edge_loc = PacketLocation::Edge(Edge {
+        source: PortRef {
+            node_name: "B".to_string(),
+            port_type: PortType::Output,
+            port_name: "out".to_string(),
+        },
+        target: PortRef {
+            node_name: "C".to_string(),
+            port_type: PortType::Input,
+            port_name: "in".to_string(),
+        },
+    });
+    assert_eq!(net.packet_count_at(&edge_loc), 1);
+    assert_eq!(net.get_epoch(&epoch_id).unwrap().out_salvos.len(), 1);
+
+    // Undo the send
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Verify packet is back at output port
+    assert_eq!(net.packet_count_at(&output_port_loc), 1);
+    assert_eq!(net.packet_count_at(&edge_loc), 0);
+    assert_eq!(net.get_epoch(&epoch_id).unwrap().out_salvos.len(), 0);
+}
+
+#[test]
+fn test_undo_create_epoch() {
+    let graph = linear_graph_3();
+    let mut net = NetSim::new(graph);
+
+    // Create packet at input port
+    let packet_id = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+    let input_port_loc = PacketLocation::InputPort("B".to_string(), "in".to_string());
+    net._packets.get_mut(&packet_id).unwrap().location = input_port_loc.clone();
+    net._packets_by_location
+        .get_mut(&PacketLocation::OutsideNet)
+        .unwrap()
+        .shift_remove(&packet_id);
+    net._packets_by_location
+        .get_mut(&input_port_loc)
+        .unwrap()
+        .insert(packet_id);
+
+    // Create epoch
+    let salvo = Salvo {
+        salvo_condition: "manual".to_string(),
+        packets: vec![("in".to_string(), packet_id)],
+    };
+    let action = NetAction::CreateEpoch("B".to_string(), salvo);
+    let (epoch, events) = match net.do_action(&action) {
+        NetActionResponse::Success(NetActionResponseData::CreatedEpoch(e), events) => (e, events),
+        _ => panic!("Expected CreatedEpoch response"),
+    };
+
+    let epoch_id = epoch.id;
+
+    // Verify epoch exists and packet is inside it
+    assert!(net.get_epoch(&epoch_id).is_some());
+    assert_eq!(net.get_packet(&packet_id).unwrap().location, PacketLocation::Node(epoch_id));
+
+    // Undo the creation
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Verify epoch is gone
+    assert!(net.get_epoch(&epoch_id).is_none());
+    assert!(!net.get_startable_epochs().contains(&epoch_id));
+
+    // Verify packet is back at input port
+    assert_eq!(net.get_packet(&packet_id).unwrap().location, input_port_loc);
+    assert_eq!(net.packet_count_at(&input_port_loc), 1);
+}
+
+// ========== Exact State Reproduction Tests ==========
+
+#[test]
+fn test_undo_create_packet_exact_state() {
+    let graph = linear_graph_3();
+    let mut net = NetSim::new(graph);
+
+    // Capture state before
+    let before = NetSimSnapshot::capture(&net);
+
+    // Perform action
+    let action = NetAction::CreatePacket(None);
+    let events = match net.do_action(&action) {
+        NetActionResponse::Success(_, events) => events,
+        _ => panic!("Expected success"),
+    };
+
+    // Undo
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Capture state after undo
+    let after = NetSimSnapshot::capture(&net);
+
+    // Compare
+    let diffs = before.diff(&after);
+    assert!(diffs.is_empty(), "State not exactly restored:\n{}", diffs.join("\n"));
+}
+
+#[test]
+fn test_undo_transport_packet_exact_state() {
+    let graph = linear_graph_3();
+    let mut net = NetSim::new(graph);
+
+    // Setup: create a packet
+    let packet_id = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+
+    // Capture state before transport
+    let before = NetSimSnapshot::capture(&net);
+
+    // Transport packet
+    let input_port = PacketLocation::InputPort("B".to_string(), "in".to_string());
+    let action = NetAction::TransportPacketToLocation(packet_id, input_port);
+    let events = match net.do_action(&action) {
+        NetActionResponse::Success(_, events) => events,
+        _ => panic!("Expected success"),
+    };
+
+    // Undo
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Capture state after undo
+    let after = NetSimSnapshot::capture(&net);
+
+    // Compare
+    let diffs = before.diff(&after);
+    assert!(diffs.is_empty(), "State not exactly restored:\n{}", diffs.join("\n"));
+}
+
+#[test]
+fn test_undo_run_step_exact_state() {
+    let graph = linear_graph_3();
+    let mut net = NetSim::new(graph);
+
+    // Setup: place packet on edge
+    let packet_id = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+    let edge_location = PacketLocation::Edge(Edge {
+        source: PortRef {
+            node_name: "A".to_string(),
+            port_type: PortType::Output,
+            port_name: "out".to_string(),
+        },
+        target: PortRef {
+            node_name: "B".to_string(),
+            port_type: PortType::Input,
+            port_name: "in".to_string(),
+        },
+    });
+    net._packets.get_mut(&packet_id).unwrap().location = edge_location.clone();
+    net._packets_by_location
+        .get_mut(&PacketLocation::OutsideNet)
+        .unwrap()
+        .shift_remove(&packet_id);
+    net._packets_by_location
+        .get_mut(&edge_location)
+        .unwrap()
+        .insert(packet_id);
+
+    // Capture state before RunStep
+    let before = NetSimSnapshot::capture(&net);
+
+    // Run step
+    let action = NetAction::RunStep;
+    let events = match net.do_action(&action) {
+        NetActionResponse::Success(_, events) => events,
+        _ => panic!("Expected success"),
+    };
+
+    // Undo
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Capture state after undo
+    let after = NetSimSnapshot::capture(&net);
+
+    // Compare
+    let diffs = before.diff(&after);
+    assert!(diffs.is_empty(), "State not exactly restored:\n{}", diffs.join("\n"));
+}
+
+#[test]
+fn test_undo_create_epoch_exact_state() {
+    let graph = linear_graph_3();
+    let mut net = NetSim::new(graph);
+
+    // Setup: place packet at input port
+    let packet_id = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+    let input_port_loc = PacketLocation::InputPort("B".to_string(), "in".to_string());
+    net._packets.get_mut(&packet_id).unwrap().location = input_port_loc.clone();
+    net._packets_by_location
+        .get_mut(&PacketLocation::OutsideNet)
+        .unwrap()
+        .shift_remove(&packet_id);
+    net._packets_by_location
+        .get_mut(&input_port_loc)
+        .unwrap()
+        .insert(packet_id);
+
+    // Capture state before CreateEpoch
+    let before = NetSimSnapshot::capture(&net);
+
+    // Create epoch
+    let salvo = Salvo {
+        salvo_condition: "manual".to_string(),
+        packets: vec![("in".to_string(), packet_id)],
+    };
+    let action = NetAction::CreateEpoch("B".to_string(), salvo);
+    let events = match net.do_action(&action) {
+        NetActionResponse::Success(_, events) => events,
+        _ => panic!("Expected success"),
+    };
+
+    // Undo
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Capture state after undo
+    let after = NetSimSnapshot::capture(&net);
+
+    // Compare
+    let diffs = before.diff(&after);
+    assert!(diffs.is_empty(), "State not exactly restored:\n{}", diffs.join("\n"));
+}
+
+#[test]
+fn test_undo_start_epoch_exact_state() {
+    let graph = linear_graph_3();
+    let mut net = NetSim::new(graph);
+
+    // Setup: create epoch
+    let packet_id = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+    let input_port_loc = PacketLocation::InputPort("B".to_string(), "in".to_string());
+    net._packets.get_mut(&packet_id).unwrap().location = input_port_loc.clone();
+    net._packets_by_location
+        .get_mut(&PacketLocation::OutsideNet)
+        .unwrap()
+        .shift_remove(&packet_id);
+    net._packets_by_location
+        .get_mut(&input_port_loc)
+        .unwrap()
+        .insert(packet_id);
+
+    let salvo = Salvo {
+        salvo_condition: "manual".to_string(),
+        packets: vec![("in".to_string(), packet_id)],
+    };
+    let epoch = get_created_epoch(&net.do_action(&NetAction::CreateEpoch("B".to_string(), salvo)));
+
+    // Capture state before StartEpoch
+    let before = NetSimSnapshot::capture(&net);
+
+    // Start epoch
+    let action = NetAction::StartEpoch(epoch.id);
+    let events = match net.do_action(&action) {
+        NetActionResponse::Success(_, events) => events,
+        _ => panic!("Expected success"),
+    };
+
+    // Undo
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Capture state after undo
+    let after = NetSimSnapshot::capture(&net);
+
+    // Compare
+    let diffs = before.diff(&after);
+    assert!(diffs.is_empty(), "State not exactly restored:\n{}", diffs.join("\n"));
+}
+
+#[test]
+fn test_undo_finish_epoch_exact_state() {
+    let graph = linear_graph_3();
+    let mut net = NetSim::new(graph);
+
+    // Setup: create, start, and empty epoch
+    let packet_id = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+    let input_port_loc = PacketLocation::InputPort("B".to_string(), "in".to_string());
+    net._packets.get_mut(&packet_id).unwrap().location = input_port_loc.clone();
+    net._packets_by_location
+        .get_mut(&PacketLocation::OutsideNet)
+        .unwrap()
+        .shift_remove(&packet_id);
+    net._packets_by_location
+        .get_mut(&input_port_loc)
+        .unwrap()
+        .insert(packet_id);
+
+    let salvo = Salvo {
+        salvo_condition: "manual".to_string(),
+        packets: vec![("in".to_string(), packet_id)],
+    };
+    let epoch = get_created_epoch(&net.do_action(&NetAction::CreateEpoch("B".to_string(), salvo)));
+    net.do_action(&NetAction::StartEpoch(epoch.id));
+    net.do_action(&NetAction::ConsumePacket(packet_id));
+
+    // Capture state before FinishEpoch
+    let before = NetSimSnapshot::capture(&net);
+
+    // Finish epoch
+    let action = NetAction::FinishEpoch(epoch.id);
+    let events = match net.do_action(&action) {
+        NetActionResponse::Success(_, events) => events,
+        _ => panic!("Expected success"),
+    };
+
+    // Undo
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Capture state after undo
+    let after = NetSimSnapshot::capture(&net);
+
+    // Compare
+    let diffs = before.diff(&after);
+    assert!(diffs.is_empty(), "State not exactly restored:\n{}", diffs.join("\n"));
+}
+
+#[test]
+fn test_undo_cancel_epoch_exact_state() {
+    let graph = linear_graph_3();
+    let mut net = NetSim::new(graph);
+
+    // Setup: create and start epoch
+    let packet_id = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+    let input_port_loc = PacketLocation::InputPort("B".to_string(), "in".to_string());
+    net._packets.get_mut(&packet_id).unwrap().location = input_port_loc.clone();
+    net._packets_by_location
+        .get_mut(&PacketLocation::OutsideNet)
+        .unwrap()
+        .shift_remove(&packet_id);
+    net._packets_by_location
+        .get_mut(&input_port_loc)
+        .unwrap()
+        .insert(packet_id);
+
+    let salvo = Salvo {
+        salvo_condition: "manual".to_string(),
+        packets: vec![("in".to_string(), packet_id)],
+    };
+    let epoch = get_created_epoch(&net.do_action(&NetAction::CreateEpoch("B".to_string(), salvo)));
+    net.do_action(&NetAction::StartEpoch(epoch.id));
+
+    // Capture state before CancelEpoch
+    let before = NetSimSnapshot::capture(&net);
+
+    // Cancel epoch
+    let action = NetAction::CancelEpoch(epoch.id);
+    let events = match net.do_action(&action) {
+        NetActionResponse::Success(_, events) => events,
+        _ => panic!("Expected success"),
+    };
+
+    // Undo
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Capture state after undo
+    let after = NetSimSnapshot::capture(&net);
+
+    // Compare
+    let diffs = before.diff(&after);
+    assert!(diffs.is_empty(), "State not exactly restored:\n{}", diffs.join("\n"));
+}
+
+#[test]
+fn test_undo_consume_packet_exact_state() {
+    let graph = linear_graph_3();
+    let mut net = NetSim::new(graph);
+
+    // Setup: create packet
+    let packet_id = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+
+    // Capture state before ConsumePacket
+    let before = NetSimSnapshot::capture(&net);
+
+    // Consume packet
+    let action = NetAction::ConsumePacket(packet_id);
+    let events = match net.do_action(&action) {
+        NetActionResponse::Success(_, events) => events,
+        _ => panic!("Expected success"),
+    };
+
+    // Undo
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Capture state after undo
+    let after = NetSimSnapshot::capture(&net);
+
+    // Compare
+    let diffs = before.diff(&after);
+    assert!(diffs.is_empty(), "State not exactly restored:\n{}", diffs.join("\n"));
+}
+
+#[test]
+fn test_undo_send_output_salvo_exact_state() {
+    let graph = linear_graph_3();
+    let mut net = NetSim::new(graph);
+
+    // Setup: create epoch with packet in output port
+    let packet_id = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+    let input_port_loc = PacketLocation::InputPort("B".to_string(), "in".to_string());
+    net._packets.get_mut(&packet_id).unwrap().location = input_port_loc.clone();
+    net._packets_by_location
+        .get_mut(&PacketLocation::OutsideNet)
+        .unwrap()
+        .shift_remove(&packet_id);
+    net._packets_by_location
+        .get_mut(&input_port_loc)
+        .unwrap()
+        .insert(packet_id);
+
+    let salvo = Salvo {
+        salvo_condition: "manual".to_string(),
+        packets: vec![("in".to_string(), packet_id)],
+    };
+    let epoch = get_created_epoch(&net.do_action(&NetAction::CreateEpoch("B".to_string(), salvo)));
+    net.do_action(&NetAction::StartEpoch(epoch.id));
+    net.do_action(&NetAction::LoadPacketIntoOutputPort(packet_id, "out".to_string()));
+
+    // Capture state before SendOutputSalvo
+    let before = NetSimSnapshot::capture(&net);
+
+    // Send output salvo
+    let action = NetAction::SendOutputSalvo(epoch.id, "default".to_string());
+    let events = match net.do_action(&action) {
+        NetActionResponse::Success(_, events) => events,
+        _ => panic!("Expected success"),
+    };
+
+    // Undo
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Capture state after undo
+    let after = NetSimSnapshot::capture(&net);
+
+    // Compare
+    let diffs = before.diff(&after);
+    assert!(diffs.is_empty(), "State not exactly restored:\n{}", diffs.join("\n"));
+}
+
+#[test]
+fn test_undo_load_packet_into_output_port_exact_state() {
+    let graph = linear_graph_3();
+    let mut net = NetSim::new(graph);
+
+    // Setup: create epoch with packet
+    let packet_id = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+    let input_port_loc = PacketLocation::InputPort("B".to_string(), "in".to_string());
+    net._packets.get_mut(&packet_id).unwrap().location = input_port_loc.clone();
+    net._packets_by_location
+        .get_mut(&PacketLocation::OutsideNet)
+        .unwrap()
+        .shift_remove(&packet_id);
+    net._packets_by_location
+        .get_mut(&input_port_loc)
+        .unwrap()
+        .insert(packet_id);
+
+    let salvo = Salvo {
+        salvo_condition: "manual".to_string(),
+        packets: vec![("in".to_string(), packet_id)],
+    };
+    let epoch = get_created_epoch(&net.do_action(&NetAction::CreateEpoch("B".to_string(), salvo)));
+    net.do_action(&NetAction::StartEpoch(epoch.id));
+
+    // Capture state before LoadPacketIntoOutputPort
+    let before = NetSimSnapshot::capture(&net);
+
+    // Load packet into output port
+    let action = NetAction::LoadPacketIntoOutputPort(packet_id, "out".to_string());
+    let events = match net.do_action(&action) {
+        NetActionResponse::Success(_, events) => events,
+        _ => panic!("Expected success"),
+    };
+
+    // Undo
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Capture state after undo
+    let after = NetSimSnapshot::capture(&net);
+
+    // Compare
+    let diffs = before.diff(&after);
+    assert!(diffs.is_empty(), "State not exactly restored:\n{}", diffs.join("\n"));
+}
+
+#[test]
+fn test_undo_multiple_packets_exact_ordering() {
+    // Test that undoing preserves exact packet ordering with multiple packets
+    let graph = linear_graph_3();
+    let mut net = NetSim::new(graph);
+
+    // Create 5 packets
+    let p1 = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+    let p2 = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+    let p3 = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+    let p4 = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+    let p5 = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+
+    // Capture state with 5 packets
+    let before = NetSimSnapshot::capture(&net);
+
+    // Move p3 (middle packet) to input port
+    let input_port = PacketLocation::InputPort("B".to_string(), "in".to_string());
+    let action = NetAction::TransportPacketToLocation(p3, input_port);
+    let events = match net.do_action(&action) {
+        NetActionResponse::Success(_, events) => events,
+        _ => panic!("Expected success"),
+    };
+
+    // Verify ordering after move: should be [p1, p2, p4, p5]
+    let order_after_move = net.get_packets_at_location(&PacketLocation::OutsideNet);
+    assert_eq!(order_after_move, vec![p1, p2, p4, p5]);
+
+    // Undo
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Capture state after undo
+    let after = NetSimSnapshot::capture(&net);
+
+    // Verify exact ordering restored: should be [p1, p2, p3, p4, p5]
+    let order_after_undo = net.get_packets_at_location(&PacketLocation::OutsideNet);
+    assert_eq!(order_after_undo, vec![p1, p2, p3, p4, p5],
+        "Exact packet ordering must be restored");
+
+    // Full state comparison
+    let diffs = before.diff(&after);
+    assert!(diffs.is_empty(), "State not exactly restored:\n{}", diffs.join("\n"));
+}
+
+#[test]
+fn test_undo_complex_run_step_exact_state() {
+    // Test undo of RunStep with multiple packets moving and multiple epochs created
+    let graph = branching_graph(); // A -> B, A -> C
+    let mut net = NetSim::new(graph);
+
+    // Place packets on both edges from A
+    let p1 = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+    let p2 = get_packet_id(&net.do_action(&NetAction::CreatePacket(None)));
+
+    let edge_a_b = PacketLocation::Edge(Edge {
+        source: PortRef {
+            node_name: "A".to_string(),
+            port_type: PortType::Output,
+            port_name: "out1".to_string(),
+        },
+        target: PortRef {
+            node_name: "B".to_string(),
+            port_type: PortType::Input,
+            port_name: "in".to_string(),
+        },
+    });
+    let edge_a_c = PacketLocation::Edge(Edge {
+        source: PortRef {
+            node_name: "A".to_string(),
+            port_type: PortType::Output,
+            port_name: "out2".to_string(),
+        },
+        target: PortRef {
+            node_name: "C".to_string(),
+            port_type: PortType::Input,
+            port_name: "in".to_string(),
+        },
+    });
+
+    // Move p1 to edge A->B
+    net._packets.get_mut(&p1).unwrap().location = edge_a_b.clone();
+    net._packets_by_location
+        .get_mut(&PacketLocation::OutsideNet)
+        .unwrap()
+        .shift_remove(&p1);
+    net._packets_by_location
+        .get_mut(&edge_a_b)
+        .unwrap()
+        .insert(p1);
+
+    // Move p2 to edge A->C
+    net._packets.get_mut(&p2).unwrap().location = edge_a_c.clone();
+    net._packets_by_location
+        .get_mut(&PacketLocation::OutsideNet)
+        .unwrap()
+        .shift_remove(&p2);
+    net._packets_by_location
+        .get_mut(&edge_a_c)
+        .unwrap()
+        .insert(p2);
+
+    // Capture state before RunStep
+    let before = NetSimSnapshot::capture(&net);
+
+    // Run step - should move both packets and create 2 epochs
+    let action = NetAction::RunStep;
+    let events = match net.do_action(&action) {
+        NetActionResponse::Success(_, events) => events,
+        _ => panic!("Expected success"),
+    };
+
+    // Verify 2 epochs were created
+    assert_eq!(net.get_startable_epochs().len(), 2);
+
+    // Undo
+    net.undo_action(&action, &events).expect("Undo should succeed");
+
+    // Capture state after undo
+    let after = NetSimSnapshot::capture(&net);
+
+    // Verify no epochs exist
+    assert_eq!(net.get_startable_epochs().len(), 0);
+
+    // Full state comparison
+    let diffs = before.diff(&after);
+    assert!(diffs.is_empty(), "State not exactly restored:\n{}", diffs.join("\n"));
 }

--- a/netrun-sim/core/tests/net_api.rs
+++ b/netrun-sim/core/tests/net_api.rs
@@ -229,15 +229,9 @@ fn test_run_until_blocked_on_empty_net() {
     let graph = common::linear_graph_3();
     let mut net = NetSim::new(graph);
 
-    let response = net.do_action(&NetAction::RunNetUntilBlocked);
+    let events = net.run_until_blocked();
 
-    // Should succeed with no events (nothing to do)
-    assert!(matches!(
-        response,
-        NetActionResponse::Success(NetActionResponseData::None, _)
-    ));
-
-    let events = get_events(&response);
+    // Should return empty events (nothing to do)
     assert!(events.is_empty());
 }
 
@@ -295,9 +289,10 @@ fn test_packet_consumed_event_structure() {
 
     assert_eq!(events.len(), 1);
     match &events[0] {
-        NetEvent::PacketConsumed(timestamp, consumed_id) => {
+        NetEvent::PacketConsumed(timestamp, consumed_id, location) => {
             assert!(*timestamp > 0);
             assert_eq!(*consumed_id, packet_id);
+            assert!(matches!(location, PacketLocation::OutsideNet));
         }
         _ => panic!("Expected PacketConsumed event"),
     }
@@ -420,7 +415,7 @@ fn test_get_startable_epochs() {
     ));
 
     // Run until blocked
-    net.do_action(&NetAction::RunNetUntilBlocked);
+    net.run_until_blocked();
 
     // Should now have a startable epoch
     let startable = net.get_startable_epochs();

--- a/netrun-sim/core/tests/workflow.rs
+++ b/netrun-sim/core/tests/workflow.rs
@@ -79,8 +79,7 @@ fn test_complete_linear_flow_a_to_b() {
     ));
 
     // 3. Run until blocked - packet should move to input port and trigger epoch
-    let response = net.do_action(&NetAction::RunNetUntilBlocked);
-    let events = get_events(&response);
+    let events = net.run_until_blocked();
 
     // Should have events: PacketMoved (to input port), PacketMoved (to node), EpochCreated, InputSalvoTriggered
     assert!(
@@ -182,7 +181,7 @@ fn test_branching_flow() {
     ));
 
     // Run until blocked
-    net.do_action(&NetAction::RunNetUntilBlocked);
+    net.run_until_blocked();
 
     // Both B and C should have startable epochs
     let epoch_ids = net.get_startable_epochs();
@@ -214,7 +213,7 @@ fn test_merging_flow_both_inputs_required() {
     ));
 
     // Run until blocked
-    net.do_action(&NetAction::RunNetUntilBlocked);
+    net.run_until_blocked();
 
     // C should NOT have a startable epoch (needs both in1 and in2)
     // The default salvo condition is AND of all input ports
@@ -229,7 +228,7 @@ fn test_merging_flow_both_inputs_required() {
     ));
 
     // Run again
-    net.do_action(&NetAction::RunNetUntilBlocked);
+    net.run_until_blocked();
 
     // Now C should have a startable epoch (both inputs present)
     let epoch_ids = net.get_startable_epochs();
@@ -263,7 +262,7 @@ fn test_diamond_flow_synchronization() {
     ));
 
     // Run until blocked
-    net.do_action(&NetAction::RunNetUntilBlocked);
+    net.run_until_blocked();
 
     // B and C should have startable epochs, but not D
     let epoch_ids = net.get_startable_epochs();
@@ -317,7 +316,7 @@ fn test_cancel_epoch_workflow() {
             assert!(
                 events
                     .iter()
-                    .any(|e| matches!(e, NetEvent::PacketDestroyed(_, _)))
+                    .any(|e| matches!(e, NetEvent::PacketDestroyed(_, _, _)))
             );
             assert!(
                 events

--- a/netrun-sim/python/examples/nbs/00_basic_net.ipynb
+++ b/netrun-sim/python/examples/nbs/00_basic_net.ipynb
@@ -355,14 +355,14 @@
      "output_type": "stream",
      "text": [
       "Events in the net:\n",
-      "   NetEvent.PacketMoved(ts=1768320557610, packet_id='01KEW1WRGY3PV9ERS3BWACDG0J', from=PacketLocation.edge(A.out.out1 -> B1.in.in), to=PacketLocation.input_port(\"B1\", \"in\"))\n",
-      "   NetEvent.PacketMoved(ts=1768320557610, packet_id='01KEW1WRGYH6BCKVMW6EYS8Y8T', from=PacketLocation.edge(A.out.out2 -> B2.in.in), to=PacketLocation.input_port(\"B2\", \"in\"))\n",
-      "   NetEvent.InputSalvoTriggered(ts=1768320557610, epoch_id='01KEW1WRHASCR9HTAQHP58NCXH', condition=\"default\")\n",
-      "   NetEvent.EpochCreated(ts=1768320557610, epoch_id='01KEW1WRHASCR9HTAQHP58NCXH')\n",
-      "   NetEvent.PacketMoved(ts=1768320557610, packet_id='01KEW1WRGY3PV9ERS3BWACDG0J', from=PacketLocation.input_port(\"B1\", \"in\"), to=PacketLocation.node('01KEW1WRHASCR9HTAQHP58NCXH'))\n",
-      "   NetEvent.InputSalvoTriggered(ts=1768320557610, epoch_id='01KEW1WRHAWT4D9SJHGWZ36AEG', condition=\"default\")\n",
-      "   NetEvent.EpochCreated(ts=1768320557610, epoch_id='01KEW1WRHAWT4D9SJHGWZ36AEG')\n",
-      "   NetEvent.PacketMoved(ts=1768320557610, packet_id='01KEW1WRGYH6BCKVMW6EYS8Y8T', from=PacketLocation.input_port(\"B2\", \"in\"), to=PacketLocation.node('01KEW1WRHAWT4D9SJHGWZ36AEG'))\n"
+      "   NetEvent.PacketMoved(ts=1768429486358, packet_id='01KEZ9S08AXFYD94QMNW2TG7RY', from=PacketLocation.edge(A.out.out2 -> B2.in.in), to=PacketLocation.input_port(\"B2\", \"in\"))\n",
+      "   NetEvent.PacketMoved(ts=1768429486358, packet_id='01KEZ9S08A4B9DV22T6MWF1VWJ', from=PacketLocation.edge(A.out.out1 -> B1.in.in), to=PacketLocation.input_port(\"B1\", \"in\"))\n",
+      "   NetEvent.InputSalvoTriggered(ts=1768429486358, epoch_id='01KEZ9S08PH3HRPWFVJB67KX22', condition=\"default\")\n",
+      "   NetEvent.EpochCreated(ts=1768429486358, epoch_id='01KEZ9S08PH3HRPWFVJB67KX22')\n",
+      "   NetEvent.PacketMoved(ts=1768429486358, packet_id='01KEZ9S08A4B9DV22T6MWF1VWJ', from=PacketLocation.input_port(\"B1\", \"in\"), to=PacketLocation.node('01KEZ9S08PH3HRPWFVJB67KX22'))\n",
+      "   NetEvent.InputSalvoTriggered(ts=1768429486358, epoch_id='01KEZ9S08PJXTCEFCVH7ZN3YYD', condition=\"default\")\n",
+      "   NetEvent.EpochCreated(ts=1768429486358, epoch_id='01KEZ9S08PJXTCEFCVH7ZN3YYD')\n",
+      "   NetEvent.PacketMoved(ts=1768429486358, packet_id='01KEZ9S08AXFYD94QMNW2TG7RY', from=PacketLocation.input_port(\"B2\", \"in\"), to=PacketLocation.node('01KEZ9S08PJXTCEFCVH7ZN3YYD'))\n"
      ]
     }
    ],

--- a/netrun-sim/python/examples/pts/00_basic_net.pct.py
+++ b/netrun-sim/python/examples/pts/00_basic_net.pct.py
@@ -10,7 +10,7 @@
 # |hide
 from nblite import nbl_export
 
-nbl_export()
+nbl_export();
 
 # %%
 from netrun_sim import (
@@ -225,4 +225,4 @@ assert set([net.get_epoch(epoch_id).node_name for epoch_id in startable_epochs])
     "B2",
 }
 
-# %%
+# %% [markdown]

--- a/netrun-sim/python/examples/pts/diamond_flow.pct.py
+++ b/netrun-sim/python/examples/pts/diamond_flow.pct.py
@@ -51,7 +51,6 @@ from netrun_sim import (
 # %% [markdown]
 # ## Helper Functions
 
-
 # %%
 def create_edge(src_node: str, src_port: str, tgt_node: str, tgt_port: str) -> Edge:
     """Create an edge between two ports."""
@@ -71,7 +70,6 @@ def edge_location(
             PortRef(tgt_node, PortType.Input, tgt_port),
         )
     )
-
 
 # %% [markdown]
 # ## Creating the Nodes
@@ -95,7 +93,6 @@ print("Node A: source with outputs 'out1' (→ B) and 'out2' (→ C)")
 # ### Nodes B and C: Middle Nodes
 #
 # B and C are simple pass-through nodes. Each has one input and one output.
-
 
 # %%
 def create_simple_node(name: str) -> Node:
@@ -256,7 +253,6 @@ for epoch_id in startable:
 # 3. Create an output packet
 # 4. Send it to D
 
-
 # %%
 def process_node(net: NetSim, epoch_id) -> None:
     """Process a simple pass-through node."""
@@ -285,7 +281,6 @@ def process_node(net: NetSim, epoch_id) -> None:
     # Finish
     net.do_action(NetAction.finish_epoch(epoch.id))
     print("  Finished epoch")
-
 
 # %%
 # Process both B and C

--- a/netrun-sim/python/examples/pts/linear_flow.pct.py
+++ b/netrun-sim/python/examples/pts/linear_flow.pct.py
@@ -44,7 +44,6 @@ from netrun_sim import (
 #
 # Let's define some helper functions to reduce boilerplate when creating edges and nodes.
 
-
 # %%
 def create_edge(src_node: str, src_port: str, tgt_node: str, tgt_port: str) -> Edge:
     """Create an edge between two ports."""
@@ -64,7 +63,6 @@ def edge_location(
             PortRef(tgt_node, PortType.Input, tgt_port),
         )
     )
-
 
 # %% [markdown]
 # ## Creating the Graph


### PR DESCRIPTION
…anges

Add comprehensive undo functionality that allows any NetAction to be reversed using the events it produced. Key changes:

- Replace RunNetUntilBlocked action with RunStep (single iteration) and run_until_blocked() convenience method
- Enhance NetEvent variants with undo data (location, epoch, from_index)
- Add undo_action() method that reverses any action given its events
- Add UndoError enum for undo-specific error handling
- Add is_blocked() method to check if network can make progress
- Fix finish_epoch to properly remove from _node_to_epochs
- Add exact state reproduction tests using NetSimSnapshot comparisons
- Update Python bindings with new API and UndoError exceptions

All 112 tests pass including comprehensive exact state verification tests that ensure perfect state restoration after undo operations.