### PR TITLE
feat(netrun-ui): auto-layout with elkjs

### DIFF
--- a/netrun-ui/package-lock.json
+++ b/netrun-ui/package-lock.json
@@ -8,7 +8,8 @@
 			"name": "netrun-ui",
 			"version": "0.1.1",
 			"dependencies": {
-				"@xyflow/svelte": "^1.5.0"
+				"@xyflow/svelte": "^1.5.0",
+				"elkjs": "^0.11.0"
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-static": "^3.0.0",
@@ -1269,6 +1270,12 @@
 			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
 			"integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
 			"license": "MIT"
+		},
+		"node_modules/elkjs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.11.0.tgz",
+			"integrity": "sha512-u4J8h9mwEDaYMqo0RYJpqNMFDoMK7f+pu4GjcV+N8jIC7TRdORgzkfSjTJemhqONFfH6fBI3wpysgWbhgVWIXw==",
+			"license": "EPL-2.0"
 		},
 		"node_modules/esbuild": {
 			"version": "0.27.2",

--- a/netrun-ui/package.json
+++ b/netrun-ui/package.json
@@ -22,6 +22,7 @@
 		"vite": "^7.3.1"
 	},
 	"dependencies": {
-		"@xyflow/svelte": "^1.5.0"
+		"@xyflow/svelte": "^1.5.0",
+		"elkjs": "^0.11.0"
 	}
 }

--- a/netrun-ui/src/lib/commands.ts
+++ b/netrun-ui/src/lib/commands.ts
@@ -11,6 +11,9 @@ import {
 	type CommandCategory,
 	openCommandPalette,
 } from '$lib/stores/commandStore';
+import { LAYOUT_ALGORITHMS, computeLayout } from '$lib/utils/autoLayout';
+import { svelteFlowRef } from '$lib/stores/svelteFlowStore';
+import { toasts } from '$lib/stores/toastStore';
 import {
 	recipes,
 	getRecipePrompts,
@@ -40,6 +43,9 @@ import {
 	selectedNode,
 	selectedNodeIds,
 	nodes,
+	edges,
+	pushHistory,
+	updateNodePositions,
 	addNode,
 	createRegularNode,
 	createFactoryNode,
@@ -546,6 +552,47 @@ const recipeStaticCommands: Command[] = [
 	},
 ];
 
+// --- Layout Commands ---
+
+async function runLayout(algorithmId: string): Promise<void> {
+	const currentNodes = get(nodes);
+	if (currentNodes.length < 2) {
+		toasts.info(currentNodes.length === 0 ? 'No nodes to layout.' : 'Need at least 2 nodes to layout.');
+		return;
+	}
+
+	const flowRef = get(svelteFlowRef);
+	if (!flowRef) {
+		toasts.error('Flow editor not available.');
+		return;
+	}
+
+	const measuredNodes = flowRef.getNodes();
+	const nodeDimensions = new Map<string, { width: number; height: number }>();
+	for (const n of measuredNodes) {
+		if (n.measured?.width && n.measured?.height) {
+			nodeDimensions.set(n.id, { width: n.measured.width, height: n.measured.height });
+		}
+	}
+
+	const currentEdges = get(edges);
+	const result = await computeLayout(currentNodes, currentEdges, algorithmId, nodeDimensions);
+
+	pushHistory();
+	updateNodePositions(result.positions);
+	flowRef.fitView({ padding: 0.2, maxZoom: 1.5 });
+}
+
+const layoutCommands: Command[] = LAYOUT_ALGORITHMS.map((algo) => ({
+	id: `layout.${algo.id}`,
+	label: `Layout: ${algo.label}`,
+	category: 'layout' as CommandCategory,
+	keywords: ['layout', 'arrange', 'auto', 'graph', algo.elkAlgorithm],
+	shortcut: algo.id === 'layered-lr' ? '\u21E7\u2318L' : undefined,
+	action: () => runLayout(algo.id),
+	enabled: () => get(nodes).length >= 2,
+}));
+
 // --- Tab Commands ---
 
 const tabCommands: Command[] = [
@@ -650,6 +697,9 @@ const keyboardShortcuts: ShortcutBinding[] = [
 	// View
 	{ key: 'p', metaKey: true, shiftKey: true, commandId: 'view.commandPalette' },
 
+	// Layout
+	{ key: 'l', metaKey: true, shiftKey: true, commandId: 'layout.layered-lr' },
+
 	// Subgraph
 	{ key: 'g', metaKey: true, commandId: 'subgraph.create' },
 
@@ -745,6 +795,7 @@ export function initializeCommands(): void {
 		...fileCommands,
 		...editCommands,
 		...viewCommands,
+		...layoutCommands,
 		...nodeCommands,
 		...subgraphCommands,
 		...recipeStaticCommands,

--- a/netrun-ui/src/lib/components/FlowEditor.svelte
+++ b/netrun-ui/src/lib/components/FlowEditor.svelte
@@ -14,9 +14,10 @@
 		ConnectionLineType
 	} from '@xyflow/svelte';
 	import '@xyflow/svelte/dist/style.css';
-	import { tick, onMount } from 'svelte';
+	import { tick, onMount, onDestroy } from 'svelte';
 	import { derived, get } from 'svelte/store';
 	import { isValidConnection, activeTabId } from '$lib/stores/flowStore';
+	import { svelteFlowRef } from '$lib/stores/svelteFlowStore';
 
 	import NetrunNodeComponent from './NetrunNode.svelte';
 	import SubgraphNodeComponent from './SubgraphNode.svelte';
@@ -302,7 +303,15 @@
 	}
 
 	// Get SvelteFlow instance for programmatic control
-	const { fitView } = useSvelteFlow();
+	const { fitView, getNodes } = useSvelteFlow();
+
+	// Expose SvelteFlow methods outside the provider boundary
+	onMount(() => {
+		svelteFlowRef.set({ fitView, getNodes });
+	});
+	onDestroy(() => {
+		svelteFlowRef.set(null);
+	});
 
 	// Fit view options - ensure entire graph is visible with padding
 	const fitViewOptions = {

--- a/netrun-ui/src/lib/components/LayoutDropdown.svelte
+++ b/netrun-ui/src/lib/components/LayoutDropdown.svelte
@@ -1,0 +1,176 @@
+<script lang="ts">
+	import { get } from 'svelte/store';
+	import { LAYOUT_ALGORITHMS, computeLayout } from '$lib/utils/autoLayout';
+	import { svelteFlowRef } from '$lib/stores/svelteFlowStore';
+	import { nodes, edges, pushHistory, updateNodePositions } from '$lib/stores/flowStore';
+	import { toasts } from '$lib/stores/toastStore';
+
+	let isOpen = $state(false);
+	let isLayingOut = $state(false);
+
+	function toggle() {
+		isOpen = !isOpen;
+	}
+
+	function closeDropdown() {
+		isOpen = false;
+	}
+
+	async function applyLayout(algorithmId: string) {
+		isOpen = false;
+
+		const currentNodes = get(nodes);
+		if (currentNodes.length < 2) {
+			toasts.info(currentNodes.length === 0 ? 'No nodes to layout.' : 'Need at least 2 nodes to layout.');
+			return;
+		}
+
+		const flowRef = get(svelteFlowRef);
+		if (!flowRef) {
+			toasts.error('Flow editor not available.');
+			return;
+		}
+
+		isLayingOut = true;
+		try {
+			// Get measured dimensions from SvelteFlow's internal state
+			const measuredNodes = flowRef.getNodes();
+			const nodeDimensions = new Map<string, { width: number; height: number }>();
+			for (const n of measuredNodes) {
+				if (n.measured?.width && n.measured?.height) {
+					nodeDimensions.set(n.id, { width: n.measured.width, height: n.measured.height });
+				}
+			}
+
+			const currentEdges = get(edges);
+			const result = await computeLayout(currentNodes, currentEdges, algorithmId, nodeDimensions);
+
+			pushHistory();
+			updateNodePositions(result.positions);
+			flowRef.fitView({ padding: 0.2, maxZoom: 1.5 });
+		} catch (e) {
+			toasts.error(`Layout failed: ${(e as Error).message}`);
+		} finally {
+			isLayingOut = false;
+		}
+	}
+</script>
+
+<svelte:window onclick={(e) => {
+	if (isOpen) {
+		const target = e.target as HTMLElement;
+		if (!target.closest('.layout-dropdown')) {
+			closeDropdown();
+		}
+	}
+}} />
+
+<div class="layout-dropdown">
+	<button class="layout-button" onclick={toggle} disabled={isLayingOut}>
+		<span class="icon">&#x2B9E;</span>
+		<span class="label">{isLayingOut ? 'Laying out...' : 'Layout'}</span>
+		<span class="caret">{isOpen ? '\u25B4' : '\u25BE'}</span>
+	</button>
+
+	{#if isOpen}
+		<div class="dropdown-menu">
+			{#each LAYOUT_ALGORITHMS as algo}
+				<button class="dropdown-item" onclick={() => applyLayout(algo.id)}>
+					<span class="item-label">{algo.label}</span>
+					<span class="item-desc">{algo.description}</span>
+				</button>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.layout-dropdown {
+		position: relative;
+	}
+
+	.layout-button {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		padding: 6px 12px;
+		background: var(--bg-tertiary, #2d2d2d);
+		border: 1px solid transparent;
+		border-radius: 4px;
+		color: var(--text-primary, #fff);
+		font-size: 12px;
+		cursor: pointer;
+		transition: all 0.15s ease;
+	}
+
+	.layout-button:hover:not(:disabled) {
+		background: var(--border-color, #404040);
+		border-color: var(--border-color, #404040);
+	}
+
+	.layout-button:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.icon {
+		font-size: 14px;
+	}
+
+	.label {
+		font-weight: 500;
+	}
+
+	.caret {
+		font-size: 10px;
+		opacity: 0.7;
+	}
+
+	.dropdown-menu {
+		position: absolute;
+		top: 100%;
+		right: 0;
+		margin-top: 4px;
+		min-width: 260px;
+		background: var(--bg-secondary, #242424);
+		border: 1px solid var(--border-color, #404040);
+		border-radius: 6px;
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+		z-index: 100;
+		overflow: hidden;
+	}
+
+	.dropdown-item {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 2px;
+		width: 100%;
+		padding: 8px 12px;
+		background: none;
+		border: none;
+		border-radius: 0;
+		color: var(--text-primary, #fff);
+		font-size: 12px;
+		cursor: pointer;
+		text-align: left;
+		transition: background 0.1s ease;
+	}
+
+	.dropdown-item:hover {
+		background: var(--bg-tertiary, #2d2d2d);
+	}
+
+	.dropdown-item + .dropdown-item {
+		border-top: 1px solid var(--border-color, #404040);
+	}
+
+	.item-label {
+		font-weight: 500;
+	}
+
+	.item-desc {
+		font-size: 11px;
+		color: var(--text-secondary, #a0a0a0);
+	}
+</style>

--- a/netrun-ui/src/lib/components/Toolbar.svelte
+++ b/netrun-ui/src/lib/components/Toolbar.svelte
@@ -22,6 +22,7 @@
 	} from '$lib/stores/flowStore';
 	import { tick } from 'svelte';
 	import { openCommandPalette } from '$lib/stores/commandStore';
+	import LayoutDropdown from './LayoutDropdown.svelte';
 	import { resolveFilePath } from '$lib/stores/fileExplorerStore';
 	import { showPrompt, showAlert, showConfirm } from '$lib/stores/modalStore';
 	import { showFactorySelector } from '$lib/stores/factorySelectorStore';
@@ -306,6 +307,8 @@
 				<span class="error-badge">{lastValidationResult.errorCount + lastValidationResult.configErrors.length}</span>
 			{/if}
 		</button>
+		<div class="separator"></div>
+		<LayoutDropdown />
 		<div class="separator"></div>
 		<button onclick={handleAddNode} title="Add regular node">
 			<span class="icon">+</span>

--- a/netrun-ui/src/lib/stores/commandStore.ts
+++ b/netrun-ui/src/lib/stores/commandStore.ts
@@ -5,7 +5,7 @@
  */
 import { writable, derived, get } from 'svelte/store';
 
-export type CommandCategory = 'file' | 'edit' | 'view' | 'node' | 'subgraph' | 'tab' | 'action' | 'recipe';
+export type CommandCategory = 'file' | 'edit' | 'view' | 'layout' | 'node' | 'subgraph' | 'tab' | 'action' | 'recipe';
 
 export interface Command {
 	id: string;
@@ -193,7 +193,7 @@ export function getCommandsByCategory(): Map<CommandCategory, Command[]> {
 	const cmds = get(commands);
 	const grouped = new Map<CommandCategory, Command[]>();
 
-	const categoryOrder: CommandCategory[] = ['file', 'edit', 'view', 'node', 'subgraph', 'tab', 'action', 'recipe'];
+	const categoryOrder: CommandCategory[] = ['file', 'edit', 'view', 'layout', 'node', 'subgraph', 'tab', 'action', 'recipe'];
 
 	for (const category of categoryOrder) {
 		grouped.set(category, []);
@@ -243,6 +243,7 @@ export const categoryLabels: Record<CommandCategory, string> = {
 	file: 'File',
 	edit: 'Edit',
 	view: 'View',
+	layout: 'Layout',
 	node: 'Node',
 	subgraph: 'Subgraph',
 	tab: 'Tab',

--- a/netrun-ui/src/lib/stores/svelteFlowStore.ts
+++ b/netrun-ui/src/lib/stores/svelteFlowStore.ts
@@ -1,0 +1,14 @@
+/**
+ * Store to share SvelteFlow instance methods outside the SvelteFlowProvider boundary.
+ *
+ * FlowEditor.svelte populates this on mount; Toolbar and commands consume it.
+ */
+import { writable } from 'svelte/store';
+import type { FitViewOptions } from '@xyflow/svelte';
+
+export interface SvelteFlowRef {
+	fitView: (options?: FitViewOptions) => void;
+	getNodes: () => Array<{ id: string; position: { x: number; y: number }; measured?: { width?: number; height?: number } }>;
+}
+
+export const svelteFlowRef = writable<SvelteFlowRef | null>(null);

--- a/netrun-ui/src/lib/utils/autoLayout.ts
+++ b/netrun-ui/src/lib/utils/autoLayout.ts
@@ -1,0 +1,190 @@
+/**
+ * Auto-layout utilities using ELK.js (Eclipse Layout Kernel).
+ *
+ * Converts SvelteFlow nodes/edges into an ELK graph, runs layout,
+ * and returns the computed positions.
+ */
+import ELK, { type ElkNode, type ElkPort, type ElkExtendedEdge } from 'elkjs/lib/elk.bundled.js';
+import type { Node, Edge } from '@xyflow/svelte';
+
+// Module-level singleton
+const elk = new ELK();
+
+export interface LayoutAlgorithm {
+	id: string;
+	label: string;
+	description: string;
+	elkAlgorithm: string;
+	elkDirection?: string; // RIGHT, DOWN, etc.
+	extraOptions?: Record<string, string>;
+}
+
+export const LAYOUT_ALGORITHMS: LayoutAlgorithm[] = [
+	{
+		id: 'layered-lr',
+		label: 'Layered L\u2192R',
+		description: 'Sugiyama layered layout, left to right',
+		elkAlgorithm: 'layered',
+		elkDirection: 'RIGHT',
+	},
+	{
+		id: 'layered-tb',
+		label: 'Layered T\u2193B',
+		description: 'Sugiyama layered layout, top to bottom',
+		elkAlgorithm: 'layered',
+		elkDirection: 'DOWN',
+	},
+	{
+		id: 'tree-lr',
+		label: 'Tree L\u2192R',
+		description: 'Tree layout, left to right',
+		elkAlgorithm: 'mrtree',
+		elkDirection: 'RIGHT',
+	},
+	{
+		id: 'tree-tb',
+		label: 'Tree T\u2193B',
+		description: 'Tree layout, top to bottom',
+		elkAlgorithm: 'mrtree',
+		elkDirection: 'DOWN',
+	},
+	{
+		id: 'force',
+		label: 'Force',
+		description: 'Force-directed layout (works with cycles)',
+		elkAlgorithm: 'force',
+	},
+	{
+		id: 'stress',
+		label: 'Stress',
+		description: 'Stress-minimization layout (works with cycles)',
+		elkAlgorithm: 'stress',
+	},
+];
+
+const DEFAULT_WIDTH = 200;
+const DEFAULT_HEIGHT = 100;
+
+export interface NodeDimensions {
+	width: number;
+	height: number;
+}
+
+export interface LayoutResult {
+	positions: Array<{ id: string; position: { x: number; y: number } }>;
+}
+
+/**
+ * Compute layout positions for the given nodes and edges.
+ */
+export async function computeLayout(
+	nodes: Node[],
+	edges: Edge[],
+	algorithmId: string,
+	nodeDimensions?: Map<string, NodeDimensions>,
+): Promise<LayoutResult> {
+	const algorithm = LAYOUT_ALGORITHMS.find((a) => a.id === algorithmId);
+	if (!algorithm) {
+		throw new Error(`Unknown layout algorithm: ${algorithmId}`);
+	}
+
+	const isHorizontal = algorithm.elkDirection === 'RIGHT' || algorithm.elkDirection === 'LEFT';
+
+	// Build ELK graph
+	const elkNodes: ElkNode[] = nodes.map((node) => {
+		const dims = nodeDimensions?.get(node.id);
+		const width = dims?.width ?? DEFAULT_WIDTH;
+		const height = dims?.height ?? DEFAULT_HEIGHT;
+
+		const ports: ElkPort[] = [];
+		const data = node.data as Record<string, unknown> | undefined;
+		const inPorts = (data?.inPorts as Array<{ name: string }>) ?? [];
+		const outPorts = (data?.outPorts as Array<{ name: string }>) ?? [];
+
+		// Input ports
+		inPorts.forEach((port, i) => {
+			ports.push({
+				id: `${node.id}__in__${port.name}`,
+				layoutOptions: {
+					'port.side': isHorizontal ? 'WEST' : 'NORTH',
+					'port.index': String(i),
+				},
+			});
+		});
+
+		// Output ports
+		outPorts.forEach((port, i) => {
+			ports.push({
+				id: `${node.id}__out__${port.name}`,
+				layoutOptions: {
+					'port.side': isHorizontal ? 'EAST' : 'SOUTH',
+					'port.index': String(i),
+				},
+			});
+		});
+
+		return {
+			id: node.id,
+			width,
+			height,
+			ports,
+		};
+	});
+
+	// Collect all port IDs that were actually created so edges only reference existing ports
+	const portIds = new Set<string>();
+	for (const elkNode of elkNodes) {
+		for (const port of elkNode.ports ?? []) {
+			portIds.add(port.id);
+		}
+	}
+
+	// Build a set of valid node IDs for edge filtering
+	const nodeIds = new Set(nodes.map((n) => n.id));
+
+	const elkEdges: ElkExtendedEdge[] = edges
+		.filter((e) => nodeIds.has(e.source) && nodeIds.has(e.target))
+		.map((edge) => {
+			const sourcePortId = edge.sourceHandle
+				? `${edge.source}__out__${edge.sourceHandle}`
+				: undefined;
+			const targetPortId = edge.targetHandle
+				? `${edge.target}__in__${edge.targetHandle}`
+				: undefined;
+
+			return {
+				id: edge.id,
+				sources: [sourcePortId && portIds.has(sourcePortId) ? sourcePortId : edge.source],
+				targets: [targetPortId && portIds.has(targetPortId) ? targetPortId : edge.target],
+			};
+		});
+
+	const layoutOptions: Record<string, string> = {
+		'elk.algorithm': algorithm.elkAlgorithm,
+		'elk.spacing.nodeNode': '80',
+		'elk.layered.spacing.nodeNodeBetweenLayers': '100',
+		'elk.spacing.portPort': '8',
+		'elk.portConstraints': 'FIXED_SIDE',
+		...algorithm.extraOptions,
+	};
+
+	if (algorithm.elkDirection) {
+		layoutOptions['elk.direction'] = algorithm.elkDirection;
+	}
+
+	const elkGraph: ElkNode = {
+		id: 'root',
+		children: elkNodes,
+		edges: elkEdges,
+		layoutOptions,
+	};
+
+	const result = await elk.layout(elkGraph);
+
+	const positions: LayoutResult['positions'] = (result.children ?? []).map((child) => ({
+		id: child.id,
+		position: { x: child.x ?? 0, y: child.y ?? 0 },
+	}));
+
+	return { positions };
+}


### PR DESCRIPTION
## Summary
- Add auto-layout toolbar dropdown and command palette commands powered by ELK.js
- Six layout algorithms: Layered L→R/T↓B, Tree L→R/T↓B, Force, and Stress
- Port-aware layout with direction-dependent port sides (WEST/EAST for horizontal, NORTH/SOUTH for vertical)
- Keyboard shortcut Cmd+Shift+L for default Layered L→R layout
- Undo support — pushHistory before applying positions
- Graceful fallback when edge references a port not present in node data (e.g. unresolved factory nodes)

## Test plan
- [ ] Create several nodes with edges → Layout → Layered L→R → nodes arrange left-to-right
- [ ] Try each algorithm from the dropdown
- [ ] Empty canvas → shows info toast, no crash
- [ ] Single node → shows info toast, no crash
- [ ] Cmd+Z after layout → reverts to previous positions
- [ ] Command palette → search "layout" → all algorithm commands appear
- [ ] Cmd+Shift+L triggers Layered L→R layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)