### PR TITLE
feat(netrun-ui): add decoration nodes

### DIFF
--- a/netrun-ui/netrun_ui_backend/converter.py
+++ b/netrun-ui/netrun_ui_backend/converter.py
@@ -445,6 +445,9 @@ def _ui_to_graph_config_model(
 
     for node in ui_nodes:
         data = node.get("data", {})
+        # Skip decoration nodes — they are visual-only and not part of the graph config
+        if data.get("nodeType") == "decoration" or node.get("type") == "decorationNode":
+            continue
         position = node.get("position", {"x": 0, "y": 0})
         node_type = data.get("nodeType")
         node_name = node["id"]

--- a/netrun-ui/netrun_ui_backend/routes/files.py
+++ b/netrun-ui/netrun_ui_backend/routes/files.py
@@ -5,7 +5,8 @@ from typing import Any
 
 import tomli
 import tomli_w
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import FileResponse
 from pydantic import BaseModel, ValidationError
 
 from ..converter import (
@@ -716,9 +717,12 @@ async def validate_config(request: ValidateRequest) -> ValidateResponse:
     """
     errors: list[ValidationError_] = []
 
+    # Filter out decoration nodes before validation
+    nodes = [n for n in request.nodes if n.get("data", {}).get("nodeType") != "decoration"]
+
     # Step 1: Build graph config (structural validation via pydantic models)
     try:
-        graph = ui_to_graph_config(request.nodes, request.edges, request.extra)
+        graph = ui_to_graph_config(nodes, request.edges, request.extra)
     except ValidationError as e:
         for err in e.errors():
             errors.append(ValidationError_(
@@ -810,3 +814,33 @@ async def validate_config(request: ValidateRequest) -> ValidateResponse:
                 type="validation_error",
             )],
         )
+
+
+# --- Image serving for decoration nodes ---
+
+_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".bmp", ".ico"}
+
+
+@router.get("/image")
+async def serve_image(
+    path: str = Query(..., description="Image path relative to project_root"),
+    project_root: str = Query(..., description="Absolute project root path"),
+) -> FileResponse:
+    """Serve an image file from the project root for decoration nodes."""
+    root = Path(project_root).resolve()
+    image_path = (root / path).resolve()
+
+    # Security: ensure the resolved path is within the project root
+    if not str(image_path).startswith(str(root)):
+        raise HTTPException(status_code=403, detail="Path traversal not allowed")
+
+    if not image_path.exists():
+        raise HTTPException(status_code=404, detail=f"Image not found: {path}")
+
+    if not image_path.is_file():
+        raise HTTPException(status_code=400, detail="Path is not a file")
+
+    if image_path.suffix.lower() not in _IMAGE_EXTENSIONS:
+        raise HTTPException(status_code=400, detail=f"Unsupported image type: {image_path.suffix}")
+
+    return FileResponse(image_path)

--- a/netrun-ui/src/app.css
+++ b/netrun-ui/src/app.css
@@ -2,7 +2,7 @@
 
 :root {
   --sidebar-width: 300px;
-  --toolbar-height: 48px;
+  --toolbar-height: 80px;
 
   /* Colors */
   --bg-primary: #1a1a1a;

--- a/netrun-ui/src/lib/api.ts
+++ b/netrun-ui/src/lib/api.ts
@@ -3,7 +3,7 @@
  */
 
 // In production, API is served from same origin. In dev, it's on port 8000.
-const API_BASE = import.meta.env.DEV ? 'http://127.0.0.1:8000/api' : '/api';
+export const API_BASE = import.meta.env.DEV ? 'http://127.0.0.1:8000/api' : '/api';
 
 export interface PortInfo {
 	name: string;

--- a/netrun-ui/src/lib/commands.ts
+++ b/netrun-ui/src/lib/commands.ts
@@ -42,6 +42,7 @@ import {
 	cutSelectedNodes,
 	selectedNode,
 	selectedNodeIds,
+	selectedEdgeIds,
 	nodes,
 	edges,
 	pushHistory,
@@ -49,6 +50,7 @@ import {
 	addNode,
 	createRegularNode,
 	createFactoryNode,
+	createDecorationNode,
 	updateFactoryNodePreview,
 	validateAllNodes,
 	createSubgraphFromSelection,
@@ -58,6 +60,7 @@ import {
 	extraData,
 	updateExtraData,
 	isExpandedChildNode,
+	type DecorationType,
 } from '$lib/stores/flowStore';
 import { showFactorySelector } from '$lib/stores/factorySelectorStore';
 import { get, derived } from 'svelte/store';
@@ -576,6 +579,74 @@ const subgraphCommands: Command[] = [
 	},
 ];
 
+// --- Decoration Commands ---
+
+function addDecorationOfType(type: DecorationType) {
+	const node = createDecorationNode({ x: 200, y: 200 }, type);
+	addNode(node);
+	selectedNodeIds.set(new Set([node.id]));
+	selectedEdgeIds.set(new Set());
+}
+
+const decorationCommands: Command[] = [
+	{
+		id: 'decoration.addRectangle',
+		label: 'Add Rectangle Decoration',
+		category: 'decoration',
+		keywords: ['shape', 'box', 'decoration'],
+		action: () => addDecorationOfType('rectangle'),
+	},
+	{
+		id: 'decoration.addRoundedRectangle',
+		label: 'Add Rounded Rectangle Decoration',
+		category: 'decoration',
+		keywords: ['shape', 'box', 'rounded', 'decoration'],
+		action: () => addDecorationOfType('rounded-rectangle'),
+	},
+	{
+		id: 'decoration.addCircle',
+		label: 'Add Circle Decoration',
+		category: 'decoration',
+		keywords: ['shape', 'oval', 'decoration'],
+		action: () => addDecorationOfType('circle'),
+	},
+	{
+		id: 'decoration.addTriangle',
+		label: 'Add Triangle Decoration',
+		category: 'decoration',
+		keywords: ['shape', 'decoration'],
+		action: () => addDecorationOfType('triangle'),
+	},
+	{
+		id: 'decoration.addDivider',
+		label: 'Add Divider',
+		category: 'decoration',
+		keywords: ['separator', 'divider', 'line', 'decoration'],
+		action: () => addDecorationOfType('divider'),
+	},
+	{
+		id: 'decoration.addLabel',
+		label: 'Add Label',
+		category: 'decoration',
+		keywords: ['label', 'annotation', 'decoration', 'text'],
+		action: () => addDecorationOfType('label'),
+	},
+	{
+		id: 'decoration.addTextbox',
+		label: 'Add Textbox',
+		category: 'decoration',
+		keywords: ['text', 'multiline', 'paragraph', 'decoration'],
+		action: () => addDecorationOfType('textbox'),
+	},
+	{
+		id: 'decoration.addImage',
+		label: 'Add Image Decoration',
+		category: 'decoration',
+		keywords: ['picture', 'photo', 'decoration', 'image'],
+		action: () => addDecorationOfType('image'),
+	},
+];
+
 // --- Recipe Commands ---
 
 const recipeStaticCommands: Command[] = [
@@ -657,8 +728,8 @@ const recipeStaticCommands: Command[] = [
 
 async function runLayout(algorithmId: string): Promise<void> {
 	const currentNodes = get(nodes);
-	// Filter out expanded child nodes - only layout parent-level nodes
-	const layoutNodes = currentNodes.filter(n => !isExpandedChildNode(n.id));
+	// Filter out expanded child nodes and decoration nodes - only layout parent-level functional nodes
+	const layoutNodes = currentNodes.filter(n => !isExpandedChildNode(n.id) && n.data.nodeType !== 'decoration');
 	if (layoutNodes.length < 2) {
 		toasts.info(layoutNodes.length === 0 ? 'No nodes to layout.' : 'Need at least 2 nodes to layout.');
 		return;
@@ -905,6 +976,7 @@ export function initializeCommands(): void {
 		...layoutCommands,
 		...nodeCommands,
 		...subgraphCommands,
+		...decorationCommands,
 		...recipeStaticCommands,
 		...tabCommands,
 	]);

--- a/netrun-ui/src/lib/components/DecorationDropdown.svelte
+++ b/netrun-ui/src/lib/components/DecorationDropdown.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+	import {
+		addNode,
+		createDecorationNode,
+		selectedNodeIds,
+		selectedEdgeIds,
+		DECORATION_TYPES,
+		type DecorationType,
+	} from '$lib/stores/flowStore';
+
+	let isOpen = $state(false);
+
+	function toggle() {
+		isOpen = !isOpen;
+	}
+
+	function closeDropdown() {
+		isOpen = false;
+	}
+
+	function handleAdd(decorationType: DecorationType) {
+		isOpen = false;
+		const node = createDecorationNode({ x: 200, y: 200 }, decorationType);
+		addNode(node);
+		selectedNodeIds.set(new Set([node.id]));
+		selectedEdgeIds.set(new Set());
+	}
+</script>
+
+<svelte:window onclick={(e) => {
+	if (isOpen) {
+		const target = e.target as HTMLElement;
+		if (!target.closest('.decoration-dropdown')) {
+			closeDropdown();
+		}
+	}
+}} />
+
+<div class="decoration-dropdown">
+	<button class="decoration-button" onclick={toggle}>
+		<span class="icon">&#x25A0;</span>
+		<span class="label">Decor</span>
+		<span class="caret">{isOpen ? '\u25B4' : '\u25BE'}</span>
+	</button>
+
+	{#if isOpen}
+		<div class="dropdown-menu">
+			{#each DECORATION_TYPES as dt}
+				<button class="dropdown-item" onclick={() => handleAdd(dt.value)}>
+					<span class="item-icon">
+						{#if dt.value === 'rectangle'}&#x25AD;
+						{:else if dt.value === 'rounded-rectangle'}&#x25A2;
+						{:else if dt.value === 'circle'}&#x25CB;
+						{:else if dt.value === 'triangle'}&#x25B3;
+						{:else if dt.value === 'divider'}&#x2500;
+						{:else if dt.value === 'label'}T
+						{:else if dt.value === 'textbox'}&#x2263;
+						{:else if dt.value === 'image'}&#x1F5BC;
+						{/if}
+					</span>
+					<span class="item-label">{dt.label}</span>
+				</button>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.decoration-dropdown {
+		position: relative;
+	}
+
+	.decoration-button {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		padding: 6px 12px;
+		background: var(--bg-tertiary, #2d2d2d);
+		border: 1px solid transparent;
+		border-radius: 4px;
+		color: var(--text-primary, #fff);
+		font-size: 12px;
+		cursor: pointer;
+		transition: all 0.15s ease;
+	}
+
+	.decoration-button:hover {
+		background: var(--border-color, #404040);
+		border-color: var(--border-color, #404040);
+	}
+
+	.icon {
+		font-size: 14px;
+	}
+
+	.label {
+		font-weight: 500;
+	}
+
+	.caret {
+		font-size: 10px;
+		opacity: 0.7;
+	}
+
+	.dropdown-menu {
+		position: absolute;
+		top: 100%;
+		right: 0;
+		margin-top: 4px;
+		min-width: 200px;
+		background: var(--bg-secondary, #242424);
+		border: 1px solid var(--border-color, #404040);
+		border-radius: 6px;
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+		z-index: 100;
+		overflow: hidden;
+	}
+
+	.dropdown-item {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		width: 100%;
+		padding: 8px 12px;
+		background: none;
+		border: none;
+		border-radius: 0;
+		color: var(--text-primary, #fff);
+		font-size: 12px;
+		cursor: pointer;
+		text-align: left;
+		transition: background 0.1s ease;
+	}
+
+	.dropdown-item:hover {
+		background: var(--bg-tertiary, #2d2d2d);
+	}
+
+	.dropdown-item + .dropdown-item {
+		border-top: 1px solid var(--border-color, #404040);
+	}
+
+	.item-icon {
+		font-size: 16px;
+		width: 20px;
+		text-align: center;
+		opacity: 0.8;
+	}
+
+	.item-label {
+		font-weight: 500;
+	}
+</style>

--- a/netrun-ui/src/lib/components/DecorationNode.svelte
+++ b/netrun-ui/src/lib/components/DecorationNode.svelte
@@ -1,0 +1,254 @@
+<script lang="ts">
+	import { NodeResizer } from '@xyflow/svelte';
+	import type { DecorationNodeData } from '$lib/stores/flowStore';
+	import { updateNodeDimensions, pushHistory, getCurrentConfig } from '$lib/stores/flowStore';
+	import { API_BASE } from '$lib/api';
+
+	interface Props {
+		id: string;
+		data: DecorationNodeData;
+		selected?: boolean;
+	}
+
+	let { id, data, selected = false }: Props = $props();
+
+	let imageUrl = $derived.by(() => {
+		if (data.decorationType !== 'image' || !data.imagePath) return '';
+		// If already an absolute URL or data URL, use as-is
+		if (data.imagePath.startsWith('http') || data.imagePath.startsWith('data:')) {
+			return data.imagePath;
+		}
+		// Build URL to backend image endpoint
+		const config = getCurrentConfig();
+		const projectRoot = (config.project_root_path as string) || '';
+		return `${API_BASE}/files/image?path=${encodeURIComponent(data.imagePath)}&project_root=${encodeURIComponent(projectRoot)}`;
+	});
+
+	function onResizeEnd(
+		_event: unknown,
+		params: { width: number; height: number; x: number; y: number }
+	) {
+		updateNodeDimensions([
+			{
+				id,
+				width: params.width,
+				height: params.height,
+				position: { x: params.x, y: params.y },
+			},
+		]);
+		pushHistory();
+	}
+</script>
+
+<!-- No Handle components — prevents connections -->
+<NodeResizer
+	isVisible={selected}
+	minWidth={20}
+	minHeight={20}
+	onResizeEnd={onResizeEnd}
+/>
+
+<div
+	class="decoration-node"
+	class:selected
+	class:type-rectangle={data.decorationType === 'rectangle'}
+	class:type-rounded-rectangle={data.decorationType === 'rounded-rectangle'}
+	class:type-circle={data.decorationType === 'circle'}
+	class:type-triangle={data.decorationType === 'triangle'}
+	class:type-divider={data.decorationType === 'divider'}
+	class:divider-vertical={data.decorationType === 'divider' && data.orientation === 'vertical'}
+	class:type-label={data.decorationType === 'label'}
+	class:type-textbox={data.decorationType === 'textbox'}
+	class:type-image={data.decorationType === 'image'}
+	style:opacity={data.opacity ?? 1}
+	style:--fill-color={data.fillColor || 'transparent'}
+	style:--stroke-color={data.strokeColor || 'transparent'}
+	style:--stroke-width="{data.strokeWidth ?? 1}px"
+	style:--font-size="{data.fontSize ?? 14}px"
+	style:--font-color={data.fontColor || '#ffffff'}
+>
+	{#if data.decorationType === 'label'}
+		<span class="text-content">{data.text || ''}</span>
+	{:else if data.decorationType === 'textbox'}
+		<span class="textbox-content">{data.text || ''}</span>
+	{:else if data.decorationType === 'image'}
+		{#if imageUrl}
+			<img src={imageUrl} alt={data.label} class="image-content" />
+		{:else}
+			<span class="placeholder">No image</span>
+		{/if}
+		{#if data.text}
+			<span class="text-overlay">{data.text}</span>
+		{/if}
+	{:else if data.decorationType === 'triangle'}
+		<div class="triangle-shape"></div>
+		{#if data.text}
+			<span class="text-overlay">{data.text}</span>
+		{/if}
+	{:else}
+		{#if data.text}
+			<span class="text-overlay">{data.text}</span>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	.decoration-node {
+		width: 100%;
+		height: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		position: relative;
+		pointer-events: all;
+	}
+
+	/* Rectangle */
+	.type-rectangle {
+		background: var(--fill-color);
+		border: var(--stroke-width) solid var(--stroke-color);
+	}
+
+	/* Rounded Rectangle */
+	.type-rounded-rectangle {
+		background: var(--fill-color);
+		border: var(--stroke-width) solid var(--stroke-color);
+		border-radius: 12px;
+	}
+
+	/* Circle */
+	.type-circle {
+		background: var(--fill-color);
+		border: var(--stroke-width) solid var(--stroke-color);
+		border-radius: 50%;
+	}
+
+	/* Triangle — uses a child div with clip-path */
+	.type-triangle {
+		background: transparent;
+		border: none;
+	}
+
+	.triangle-shape {
+		width: 100%;
+		height: 100%;
+		background: var(--fill-color);
+		clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+		position: absolute;
+		inset: 0;
+		/* Outline effect via filter */
+	}
+
+	/* We simulate stroke via drop-shadow on the parent when stroke is set */
+	.type-triangle {
+		filter: drop-shadow(0 0 var(--stroke-width) var(--stroke-color));
+	}
+
+	/* Divider (horizontal by default) */
+	.type-divider {
+		background: transparent;
+		border: none;
+		min-height: 2px;
+		min-width: 2px;
+	}
+
+	.type-divider::after {
+		content: '';
+		position: absolute;
+		left: 0;
+		right: 0;
+		top: 50%;
+		transform: translateY(-50%);
+		height: var(--stroke-width);
+		background: var(--stroke-color);
+	}
+
+	/* Divider vertical */
+	.type-divider.divider-vertical::after {
+		left: 50%;
+		right: auto;
+		top: 0;
+		bottom: 0;
+		transform: translateX(-50%);
+		height: auto;
+		width: var(--stroke-width);
+	}
+
+	/* Label */
+	.type-label {
+		background: transparent;
+		border: none;
+	}
+
+	/* Textbox */
+	.type-textbox {
+		background: var(--fill-color);
+		border: var(--stroke-width) solid var(--stroke-color);
+		border-radius: 4px;
+		overflow: hidden;
+	}
+
+	/* Image */
+	.type-image {
+		background: var(--fill-color);
+		border: var(--stroke-width) solid var(--stroke-color);
+		overflow: hidden;
+	}
+
+	.image-content {
+		width: 100%;
+		height: 100%;
+		object-fit: contain;
+	}
+
+	.text-content {
+		font-size: var(--font-size);
+		color: var(--font-color);
+		white-space: nowrap;
+		text-align: center;
+		padding: 4px;
+		user-select: none;
+	}
+
+	.textbox-content {
+		font-size: var(--font-size);
+		color: var(--font-color);
+		white-space: pre-wrap;
+		word-break: break-word;
+		text-align: left;
+		padding: 8px;
+		width: 100%;
+		height: 100%;
+		overflow: auto;
+		user-select: none;
+	}
+
+	.text-overlay {
+		font-size: var(--font-size);
+		color: var(--font-color);
+		white-space: pre-wrap;
+		word-break: break-word;
+		text-align: center;
+		position: relative;
+		z-index: 1;
+		padding: 4px;
+		user-select: none;
+	}
+
+	.placeholder {
+		font-size: 12px;
+		color: var(--text-secondary, #a0a0a0);
+		font-style: italic;
+		user-select: none;
+	}
+
+	/* Selection highlight — handled by SvelteFlow, but add a subtle ring */
+	.selected {
+		box-shadow: 0 0 0 2px var(--accent-color, #3b82f6);
+	}
+
+	/* Ensure the triangle selection ring uses the shape */
+	.type-triangle.selected {
+		box-shadow: none;
+	}
+</style>

--- a/netrun-ui/src/lib/components/DecorationProperties.svelte
+++ b/netrun-ui/src/lib/components/DecorationProperties.svelte
@@ -1,0 +1,418 @@
+<script lang="ts">
+	import {
+		updateNodeDataLive,
+		updateNodeDimensions,
+		pushHistory,
+		deleteNodes,
+		renameNode,
+		DECORATION_TYPES,
+		type FlowNode,
+		type DecorationNodeData,
+		type DecorationType,
+	} from '$lib/stores/flowStore';
+
+	interface Props {
+		node: FlowNode;
+	}
+
+	let { node }: Props = $props();
+
+	let data = $derived(node.data as DecorationNodeData);
+
+	// Name editing
+	let editingName = $state(false);
+	let nameInput = $state('');
+
+	function startEditName() {
+		nameInput = data.label;
+		editingName = true;
+	}
+
+	function commitName() {
+		editingName = false;
+		const trimmed = nameInput.trim();
+		if (trimmed && trimmed !== data.label) {
+			pushHistory();
+			renameNode(node.id, trimmed);
+		}
+	}
+
+	function cancelName() {
+		editingName = false;
+	}
+
+	function handleNameKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter') commitName();
+		else if (e.key === 'Escape') cancelName();
+	}
+
+	// Property updates
+	function updateProp(key: keyof DecorationNodeData, value: unknown) {
+		updateNodeDataLive(node.id, { [key]: value } as Partial<DecorationNodeData>);
+	}
+
+	function updatePropWithHistory(key: keyof DecorationNodeData, value: unknown) {
+		pushHistory();
+		updateNodeDataLive(node.id, { [key]: value } as Partial<DecorationNodeData>);
+	}
+
+	function handleDelete() {
+		deleteNodes([node.id]);
+	}
+
+	function resetColor(key: 'fillColor' | 'strokeColor' | 'fontColor') {
+		pushHistory();
+		updateNodeDataLive(node.id, { [key]: undefined } as Partial<DecorationNodeData>);
+	}
+</script>
+
+<section class="section">
+	<h3 class="section-title">Decoration</h3>
+
+	<!-- Name -->
+	<div class="field">
+		<label class="field-label">Name</label>
+		{#if editingName}
+			<input
+				type="text"
+				class="field-input"
+				bind:value={nameInput}
+				onblur={commitName}
+				onkeydown={handleNameKeydown}
+			/>
+		{:else}
+			<button class="name-display" ondblclick={startEditName} title="Double-click to rename">
+				{data.label}
+			</button>
+		{/if}
+	</div>
+
+	<!-- Decoration Type -->
+	<div class="field">
+		<label class="field-label">Type</label>
+		<select
+			class="field-select"
+			value={data.decorationType}
+			onchange={(e) => updatePropWithHistory('decorationType', (e.target as HTMLSelectElement).value as DecorationType)}
+		>
+			{#each DECORATION_TYPES as dt}
+				<option value={dt.value}>{dt.label}</option>
+			{/each}
+		</select>
+	</div>
+
+	<!-- Text -->
+	<div class="field">
+		<label class="field-label">Text</label>
+		<textarea
+			class="field-textarea"
+			value={data.text || ''}
+			oninput={(e) => updateProp('text', (e.target as HTMLTextAreaElement).value || undefined)}
+			onchange={() => pushHistory()}
+			onkeydown={(e) => e.stopPropagation()}
+			placeholder="Optional text..."
+			rows={data.decorationType === 'textbox' ? 5 : 2}
+		></textarea>
+	</div>
+
+	<!-- Image Path (only for image type) -->
+	{#if data.decorationType === 'image'}
+		<div class="field">
+			<label class="field-label">Image Path</label>
+			<input
+				type="text"
+				class="field-input"
+				value={data.imagePath || ''}
+				oninput={(e) => updateProp('imagePath', (e.target as HTMLInputElement).value || undefined)}
+				onchange={() => pushHistory()}
+				placeholder="path/to/image.png"
+			/>
+		</div>
+	{/if}
+
+	<!-- Orientation (only for divider type) -->
+	{#if data.decorationType === 'divider'}
+		<div class="field">
+			<label class="field-label">Orientation</label>
+			<select
+				class="field-select"
+				value={data.orientation || 'horizontal'}
+				onchange={(e) => {
+					const newOrientation = (e.target as HTMLSelectElement).value as 'horizontal' | 'vertical';
+					pushHistory();
+					updateNodeDataLive(node.id, { orientation: newOrientation } as Partial<DecorationNodeData>);
+					const w = node.width ?? 200;
+					const h = node.height ?? 4;
+					updateNodeDimensions([{ id: node.id, width: h, height: w, position: node.position }]);
+				}}
+			>
+				<option value="horizontal">Horizontal</option>
+				<option value="vertical">Vertical</option>
+			</select>
+		</div>
+	{/if}
+</section>
+
+<section class="section">
+	<h3 class="section-title">Appearance</h3>
+
+	<!-- Fill Color -->
+	{#if data.decorationType !== 'label' && data.decorationType !== 'divider'}
+		<div class="field color-field">
+			<label class="field-label">Fill Color</label>
+			<div class="color-row">
+				<input
+					type="color"
+					class="color-input"
+					value={data.fillColor || '#374151'}
+					onchange={(e) => updatePropWithHistory('fillColor', (e.target as HTMLInputElement).value)}
+				/>
+				<span class="color-value">{data.fillColor || 'none'}</span>
+				{#if data.fillColor}
+					<button class="reset-btn" onclick={() => resetColor('fillColor')} title="Reset">x</button>
+				{/if}
+			</div>
+		</div>
+	{/if}
+
+	<!-- Stroke Color -->
+	{#if data.decorationType !== 'label'}
+		<div class="field color-field">
+			<label class="field-label">Stroke Color</label>
+			<div class="color-row">
+				<input
+					type="color"
+					class="color-input"
+					value={data.strokeColor || '#6b7280'}
+					onchange={(e) => updatePropWithHistory('strokeColor', (e.target as HTMLInputElement).value)}
+				/>
+				<span class="color-value">{data.strokeColor || 'none'}</span>
+				{#if data.strokeColor}
+					<button class="reset-btn" onclick={() => resetColor('strokeColor')} title="Reset">x</button>
+				{/if}
+			</div>
+		</div>
+
+		<!-- Stroke Width -->
+		<div class="field">
+			<label class="field-label">Stroke Width</label>
+			<input
+				type="number"
+				class="field-input narrow"
+				value={data.strokeWidth ?? 1}
+				min="0"
+				max="20"
+				step="1"
+				onchange={(e) => updatePropWithHistory('strokeWidth', Number((e.target as HTMLInputElement).value))}
+			/>
+		</div>
+	{/if}
+
+	<!-- Font Size -->
+	<div class="field">
+		<label class="field-label">Font Size</label>
+		<input
+			type="number"
+			class="field-input narrow"
+			value={data.fontSize ?? 14}
+			min="6"
+			max="200"
+			step="1"
+			onchange={(e) => updatePropWithHistory('fontSize', Number((e.target as HTMLInputElement).value))}
+		/>
+	</div>
+
+	<!-- Font Color -->
+	<div class="field color-field">
+		<label class="field-label">Font Color</label>
+		<div class="color-row">
+			<input
+				type="color"
+				class="color-input"
+				value={data.fontColor || '#ffffff'}
+				onchange={(e) => updatePropWithHistory('fontColor', (e.target as HTMLInputElement).value)}
+			/>
+			<span class="color-value">{data.fontColor || '#ffffff'}</span>
+			{#if data.fontColor}
+				<button class="reset-btn" onclick={() => resetColor('fontColor')} title="Reset">x</button>
+			{/if}
+		</div>
+	</div>
+
+	<!-- Opacity -->
+	<div class="field">
+		<label class="field-label">Opacity</label>
+		<div class="slider-row">
+			<input
+				type="range"
+				class="field-slider"
+				min="0"
+				max="1"
+				step="0.05"
+				value={data.opacity ?? 1}
+				oninput={(e) => updateProp('opacity', Number((e.target as HTMLInputElement).value))}
+				onchange={() => pushHistory()}
+			/>
+			<span class="slider-value">{((data.opacity ?? 1) * 100).toFixed(0)}%</span>
+		</div>
+	</div>
+</section>
+
+<section class="section">
+	<button class="delete-btn" onclick={handleDelete}>Delete Decoration</button>
+</section>
+
+<style>
+	.section {
+		padding: 12px 16px;
+		border-bottom: 1px solid var(--border-color, #404040);
+	}
+
+	.section-title {
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		color: var(--text-secondary, #a0a0a0);
+		margin: 0 0 8px 0;
+		letter-spacing: 0.5px;
+	}
+
+	.field {
+		margin-bottom: 8px;
+	}
+
+	.field-label {
+		display: block;
+		font-size: 11px;
+		color: var(--text-secondary, #a0a0a0);
+		margin-bottom: 4px;
+	}
+
+	.field-input,
+	.field-select,
+	.field-textarea {
+		width: 100%;
+		padding: 6px 8px;
+		background: var(--bg-tertiary, #2d2d2d);
+		border: 1px solid var(--border-color, #404040);
+		border-radius: 4px;
+		color: var(--text-primary, #fff);
+		font-size: 12px;
+		font-family: inherit;
+		box-sizing: border-box;
+	}
+
+	.field-input.narrow {
+		width: 80px;
+	}
+
+	.field-input:focus,
+	.field-select:focus,
+	.field-textarea:focus {
+		outline: none;
+		border-color: var(--accent-color, #3b82f6);
+	}
+
+	.field-textarea {
+		resize: vertical;
+		min-height: 36px;
+	}
+
+	.name-display {
+		width: 100%;
+		padding: 6px 8px;
+		background: var(--bg-tertiary, #2d2d2d);
+		border: 1px solid transparent;
+		border-radius: 4px;
+		color: var(--text-primary, #fff);
+		font-size: 12px;
+		text-align: left;
+		cursor: pointer;
+	}
+
+	.name-display:hover {
+		border-color: var(--border-color, #404040);
+	}
+
+	.color-row {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.color-input {
+		width: 32px;
+		height: 24px;
+		padding: 0;
+		border: 1px solid var(--border-color, #404040);
+		border-radius: 4px;
+		background: none;
+		cursor: pointer;
+	}
+
+	.color-input::-webkit-color-swatch-wrapper {
+		padding: 2px;
+	}
+
+	.color-input::-webkit-color-swatch {
+		border: none;
+		border-radius: 2px;
+	}
+
+	.color-value {
+		font-size: 11px;
+		color: var(--text-secondary, #a0a0a0);
+		font-family: monospace;
+	}
+
+	.reset-btn {
+		padding: 2px 6px;
+		background: var(--bg-tertiary, #2d2d2d);
+		border: 1px solid var(--border-color, #404040);
+		border-radius: 3px;
+		color: var(--text-secondary, #a0a0a0);
+		font-size: 10px;
+		cursor: pointer;
+	}
+
+	.reset-btn:hover {
+		background: var(--border-color, #404040);
+		color: var(--text-primary, #fff);
+	}
+
+	.slider-row {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.field-slider {
+		flex: 1;
+		height: 4px;
+		accent-color: var(--accent-color, #3b82f6);
+	}
+
+	.slider-value {
+		font-size: 11px;
+		color: var(--text-secondary, #a0a0a0);
+		min-width: 36px;
+		text-align: right;
+	}
+
+	.delete-btn {
+		width: 100%;
+		padding: 8px;
+		background: var(--error-color, #ef4444);
+		border: none;
+		border-radius: 4px;
+		color: #fff;
+		font-size: 12px;
+		font-weight: 500;
+		cursor: pointer;
+		transition: background 0.15s ease;
+	}
+
+	.delete-btn:hover {
+		background: #dc2626;
+	}
+</style>

--- a/netrun-ui/src/lib/components/FlowEditor.svelte
+++ b/netrun-ui/src/lib/components/FlowEditor.svelte
@@ -21,6 +21,7 @@
 
 	import NetrunNodeComponent from './NetrunNode.svelte';
 	import SubgraphNodeComponent from './SubgraphNode.svelte';
+	import DecorationNodeComponent from './DecorationNode.svelte';
 	import {
 		nodes,
 		edges,
@@ -145,7 +146,8 @@
 	// Register custom node types
 	const nodeTypes: NodeTypes = {
 		netrunNode: NetrunNodeComponent,
-		subgraphNode: SubgraphNodeComponent
+		subgraphNode: SubgraphNodeComponent,
+		decorationNode: DecorationNodeComponent,
 	};
 
 	/**
@@ -462,6 +464,7 @@
 		<Controls />
 		<MiniMap
 			nodeColor={(node) => {
+				if (node.data?.nodeType === 'decoration') return '#6b7280';
 				if (node.data?.nodeType === 'subgraph') return '#22c55e';
 				if (node.data?.nodeType === 'factory') return '#7c3aed';
 				return '#3b82f6';

--- a/netrun-ui/src/lib/components/LayoutDropdown.svelte
+++ b/netrun-ui/src/lib/components/LayoutDropdown.svelte
@@ -20,8 +20,10 @@
 		isOpen = false;
 
 		const currentNodes = get(nodes);
-		if (currentNodes.length < 2) {
-			toasts.info(currentNodes.length === 0 ? 'No nodes to layout.' : 'Need at least 2 nodes to layout.');
+		// Filter out decoration nodes — they don't participate in layout
+		const layoutNodes = currentNodes.filter(n => (n.data as Record<string, unknown>)?.nodeType !== 'decoration');
+		if (layoutNodes.length < 2) {
+			toasts.info(layoutNodes.length === 0 ? 'No nodes to layout.' : 'Need at least 2 nodes to layout.');
 			return;
 		}
 
@@ -43,7 +45,7 @@
 			}
 
 			const currentEdges = get(edges);
-			const result = await computeLayout(currentNodes, currentEdges, algorithmId, nodeDimensions);
+			const result = await computeLayout(layoutNodes, currentEdges, algorithmId, nodeDimensions);
 
 			pushHistory();
 			updateNodePositions(result.positions);

--- a/netrun-ui/src/lib/components/Sidebar.svelte
+++ b/netrun-ui/src/lib/components/Sidebar.svelte
@@ -35,6 +35,7 @@
 		type PortConfig
 	} from '$lib/stores/flowStore';
 	import { deleteExpandedChildren, renameExpandedChildNode } from '$lib/stores/subgraphExpandStore';
+	import DecorationProperties from './DecorationProperties.svelte';
 	import SalvoConditionsSection from './SalvoConditionsSection.svelte';
 	import PoolsSection from './PoolsSection.svelte';
 	import NodeExecutionSection from './NodeExecutionSection.svelte';
@@ -654,7 +655,9 @@
 	{/if}
 
 	<div class="sidebar-content">
-		{#if $selectedNode}
+		{#if $selectedNode && $selectedNode.data.nodeType === 'decoration'}
+			<DecorationProperties node={$selectedNode} />
+		{:else if $selectedNode}
 			<!-- General Section -->
 			<section class="section">
 				<button

--- a/netrun-ui/src/lib/components/Toolbar.svelte
+++ b/netrun-ui/src/lib/components/Toolbar.svelte
@@ -25,6 +25,7 @@
 	import { tick } from 'svelte';
 	import { openCommandPalette } from '$lib/stores/commandStore';
 	import LayoutDropdown from './LayoutDropdown.svelte';
+	import DecorationDropdown from './DecorationDropdown.svelte';
 	import { resolveFilePath } from '$lib/stores/fileExplorerStore';
 	import { showPrompt, showAlert, showConfirm } from '$lib/stores/modalStore';
 	import { showFactorySelector } from '$lib/stores/factorySelectorStore';
@@ -235,130 +236,146 @@
 </script>
 
 <header class="toolbar">
-	<div class="toolbar-section left">
-		<button onclick={handleNew} title="New file (Cmd+N)">
-			<span class="icon">📄</span>
-			<span class="label">New</span>
-		</button>
-		<button onclick={handleOpen} title="Open file (Cmd+O)">
-			<span class="icon">📂</span>
-			<span class="label">Open</span>
-		</button>
-		<button onclick={handleSave} title="Save file (Cmd+S)" disabled={!$isDirty}>
-			<span class="icon">💾</span>
-			<span class="label">Save</span>
-		</button>
-		<button onclick={handleReload} title="Reload file from disk (Cmd+Shift+R)" disabled={!$currentFilePath}>
-			<span class="icon">🔄</span>
-			<span class="label">Reload</span>
-		</button>
-		<div class="separator"></div>
-		<button onclick={handleUndo} title="Undo (Cmd+Z)" disabled={$history.past.length === 0}>
-			<span class="icon">↩</span>
-			<span class="label">Undo</span>
-		</button>
-		<button onclick={handleRedo} title="Redo (Cmd+Shift+Z)" disabled={$history.future.length === 0}>
-			<span class="icon">↪</span>
-			<span class="label">Redo</span>
-		</button>
+	<div class="toolbar-row">
+		<div class="toolbar-section left">
+			<button onclick={handleNew} title="New file (Cmd+N)">
+				<span class="icon">📄</span>
+				<span class="label">New</span>
+			</button>
+			<button onclick={handleOpen} title="Open file (Cmd+O)">
+				<span class="icon">📂</span>
+				<span class="label">Open</span>
+			</button>
+			<button onclick={handleSave} title="Save file (Cmd+S)" disabled={!$isDirty}>
+				<span class="icon">💾</span>
+				<span class="label">Save</span>
+			</button>
+			<button onclick={handleReload} title="Reload file from disk (Cmd+Shift+R)" disabled={!$currentFilePath}>
+				<span class="icon">🔄</span>
+				<span class="label">Reload</span>
+			</button>
+			<div class="separator"></div>
+			<button onclick={handleUndo} title="Undo (Cmd+Z)" disabled={$history.past.length === 0}>
+				<span class="icon">↩</span>
+				<span class="label">Undo</span>
+			</button>
+			<button onclick={handleRedo} title="Redo (Cmd+Shift+Z)" disabled={$history.future.length === 0}>
+				<span class="icon">↪</span>
+				<span class="label">Redo</span>
+			</button>
+		</div>
+
+		<div class="toolbar-section center">
+			{#if $currentFilePath}
+				<span class="file-name">
+					{$currentFilePath.split('/').pop()}
+					{#if $isDirty}<span class="dirty-indicator">*</span>{/if}
+				</span>
+			{:else}
+				<span class="file-name untitled">Untitled</span>
+			{/if}
+		</div>
+
+		<div class="toolbar-section right">
+			<button onclick={openCommandPalette} title="Command Palette (Cmd+Shift+P)" class="command-palette">
+				<span class="icon">⌘</span>
+			</button>
+		</div>
 	</div>
 
-	<div class="toolbar-section center">
-		{#if $currentFilePath}
-			<span class="file-name">
-				{$currentFilePath.split('/').pop()}
-				{#if $isDirty}<span class="dirty-indicator">*</span>{/if}
-			</span>
-		{:else}
-			<span class="file-name untitled">Untitled</span>
-		{/if}
-	</div>
+	<div class="toolbar-row">
+		<div class="toolbar-section left">
+			<button
+				onclick={toggleInteractionMode}
+				title={$interactionMode === 'pan'
+					? 'Pan mode: drag to pan, Shift+drag to select. Click to switch to Select mode.'
+					: 'Select mode: drag to select, right-click drag to pan. Click to switch to Pan mode.'}
+				class="mode-toggle"
+				class:select-mode={$interactionMode === 'select'}
+			>
+				{#if $interactionMode === 'pan'}
+					<span class="icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 11V6a2 2 0 0 0-4 0v1M14 10V4a2 2 0 0 0-4 0v6M10 10V6a2 2 0 0 0-4 0v8c0 4.4 3.6 8 8 8h.5a8 8 0 0 0 8-8v-4a2 2 0 0 0-4 0"/></svg></span>
+					<span class="label">Pan</span>
+				{:else}
+					<span class="icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="1" stroke-dasharray="4 2"/></svg></span>
+					<span class="label">Select</span>
+				{/if}
+			</button>
+			<div class="separator"></div>
+			<button
+				onclick={async () => {
+					isValidating = true;
+					lastValidationResult = await validateAllNodes();
+					skipNextReset = true;
+					isValidating = false;
+					if (!lastValidationResult.valid && lastValidationResult.configErrors.length > 0) {
+						await showAlert({
+							title: 'Config Errors',
+							message: lastValidationResult.configErrors.join('\n'),
+						});
+					}
+				}}
+				title="Validate all nodes"
+				disabled={isValidating}
+				class:has-errors={lastValidationResult && !lastValidationResult.valid}
+				class:has-success={lastValidationResult && lastValidationResult.valid}
+			>
+				<span class="icon">✓</span>
+				{#if isValidating}
+					<span class="label">Validating...</span>
+				{:else if lastValidationResult && lastValidationResult.valid}
+					<span class="label">Valid</span>
+				{:else}
+					<span class="label">Validate</span>
+				{/if}
+				{#if lastValidationResult && !lastValidationResult.valid}
+					<span class="error-badge">{lastValidationResult.errorCount + lastValidationResult.configErrors.length}</span>
+				{/if}
+			</button>
+			<div class="separator"></div>
+			<LayoutDropdown />
+			<DecorationDropdown />
+		</div>
 
-	<div class="toolbar-section right">
-		<button
-			onclick={toggleInteractionMode}
-			title={$interactionMode === 'pan'
-				? 'Pan mode: drag to pan, Shift+drag to select. Click to switch to Select mode.'
-				: 'Select mode: drag to select, right-click drag to pan. Click to switch to Pan mode.'}
-			class="mode-toggle"
-			class:select-mode={$interactionMode === 'select'}
-		>
-			{#if $interactionMode === 'pan'}
-				<span class="icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 11V6a2 2 0 0 0-4 0v1M14 10V4a2 2 0 0 0-4 0v6M10 10V6a2 2 0 0 0-4 0v8c0 4.4 3.6 8 8 8h.5a8 8 0 0 0 8-8v-4a2 2 0 0 0-4 0"/></svg></span>
-				<span class="label">Pan</span>
-			{:else}
-				<span class="icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="1" stroke-dasharray="4 2"/></svg></span>
-				<span class="label">Select</span>
-			{/if}
-		</button>
-		<div class="separator"></div>
-		<button onclick={openCommandPalette} title="Command Palette (Cmd+Shift+P)" class="command-palette">
-			<span class="icon">⌘</span>
-		</button>
-		<div class="separator"></div>
-		<button
-			onclick={async () => {
-				isValidating = true;
-				lastValidationResult = await validateAllNodes();
-				skipNextReset = true;
-				isValidating = false;
-				if (!lastValidationResult.valid && lastValidationResult.configErrors.length > 0) {
-					await showAlert({
-						title: 'Config Errors',
-						message: lastValidationResult.configErrors.join('\n'),
-					});
-				}
-			}}
-			title="Validate all nodes"
-			disabled={isValidating}
-			class:has-errors={lastValidationResult && !lastValidationResult.valid}
-			class:has-success={lastValidationResult && lastValidationResult.valid}
-		>
-			<span class="icon">✓</span>
-			{#if isValidating}
-				<span class="label">Validating...</span>
-			{:else if lastValidationResult && lastValidationResult.valid}
-				<span class="label">Valid</span>
-			{:else}
-				<span class="label">Validate</span>
-			{/if}
-			{#if lastValidationResult && !lastValidationResult.valid}
-				<span class="error-badge">{lastValidationResult.errorCount + lastValidationResult.configErrors.length}</span>
-			{/if}
-		</button>
-		<div class="separator"></div>
-		<LayoutDropdown />
-		<div class="separator"></div>
-		<button onclick={handleAddNode} title="Add regular node">
-			<span class="icon">+</span>
-			<span class="label">Add Node</span>
-		</button>
-		<button onclick={handleAddFactoryNode} title="Add factory node" class="factory">
-			<span class="icon">⚙</span>
-			<span class="label">Add Factory</span>
-		</button>
-		<button
-			onclick={handleCreateSubgraph}
-			title="Create subgraph from selection (Cmd+G)"
-			class="subgraph"
-			disabled={$selectedNodeIds.size < 2}
-		>
-			<span class="icon">SG</span>
-			<span class="label">Subgraph</span>
-		</button>
+		<div class="toolbar-section right">
+			<button onclick={handleAddNode} title="Add regular node">
+				<span class="icon">+</span>
+				<span class="label">Add Node</span>
+			</button>
+			<button onclick={handleAddFactoryNode} title="Add factory node" class="factory">
+				<span class="icon">⚙</span>
+				<span class="label">Add Factory</span>
+			</button>
+			<button
+				onclick={handleCreateSubgraph}
+				title="Create subgraph from selection (Cmd+G)"
+				class="subgraph"
+				disabled={$selectedNodeIds.size < 2}
+			>
+				<span class="icon">SG</span>
+				<span class="label">Subgraph</span>
+			</button>
+		</div>
 	</div>
 </header>
 
 
 <style>
 	.toolbar {
-		height: var(--toolbar-height, 48px);
+		height: var(--toolbar-height, 80px);
 		background: var(--bg-secondary, #242424);
 		border-bottom: 1px solid var(--border-color, #404040);
 		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		padding: 4px 12px;
+		gap: 2px;
+	}
+
+	.toolbar-row {
+		display: flex;
 		align-items: center;
 		justify-content: space-between;
-		padding: 0 12px;
 		gap: 16px;
 	}
 
@@ -375,9 +392,9 @@
 
 	.separator {
 		width: 1px;
-		height: 24px;
+		height: 20px;
 		background: var(--border-color, #404040);
-		margin: 0 8px;
+		margin: 0 6px;
 	}
 
 	button {

--- a/netrun-ui/src/lib/stores/commandStore.ts
+++ b/netrun-ui/src/lib/stores/commandStore.ts
@@ -5,7 +5,7 @@
  */
 import { writable, derived, get } from 'svelte/store';
 
-export type CommandCategory = 'file' | 'edit' | 'view' | 'layout' | 'node' | 'subgraph' | 'tab' | 'action' | 'recipe';
+export type CommandCategory = 'file' | 'edit' | 'view' | 'layout' | 'node' | 'subgraph' | 'decoration' | 'tab' | 'action' | 'recipe';
 
 export interface Command {
 	id: string;
@@ -193,7 +193,7 @@ export function getCommandsByCategory(): Map<CommandCategory, Command[]> {
 	const cmds = get(commands);
 	const grouped = new Map<CommandCategory, Command[]>();
 
-	const categoryOrder: CommandCategory[] = ['file', 'edit', 'view', 'layout', 'node', 'subgraph', 'tab', 'action', 'recipe'];
+	const categoryOrder: CommandCategory[] = ['file', 'edit', 'view', 'layout', 'node', 'subgraph', 'decoration', 'tab', 'action', 'recipe'];
 
 	for (const category of categoryOrder) {
 		grouped.set(category, []);
@@ -246,6 +246,7 @@ export const categoryLabels: Record<CommandCategory, string> = {
 	layout: 'Layout',
 	node: 'Node',
 	subgraph: 'Subgraph',
+	decoration: 'Decoration',
 	tab: 'Tab',
 	action: 'Action',
 	recipe: 'Recipe',

--- a/netrun-ui/src/lib/stores/flowStore.ts
+++ b/netrun-ui/src/lib/stores/flowStore.ts
@@ -92,13 +92,57 @@ export interface SubgraphNodeData extends BaseNodeData {
 	_subgraphConfig?: Record<string, unknown>;
 }
 
+// Decoration types
+export type DecorationType =
+	| 'rectangle'
+	| 'rounded-rectangle'
+	| 'circle'
+	| 'triangle'
+	| 'divider'
+	| 'label'
+	| 'textbox'
+	| 'image';
+
+export const DECORATION_TYPES: { value: DecorationType; label: string }[] = [
+	{ value: 'rectangle', label: 'Rectangle' },
+	{ value: 'rounded-rectangle', label: 'Rounded Rectangle' },
+	{ value: 'circle', label: 'Circle' },
+	{ value: 'triangle', label: 'Triangle' },
+	{ value: 'divider', label: 'Divider' },
+	{ value: 'label', label: 'Label' },
+	{ value: 'textbox', label: 'Textbox' },
+	{ value: 'image', label: 'Image' },
+];
+
+// Extended data for decoration nodes (non-functional visual annotations)
+export interface DecorationNodeData extends Record<string, unknown> {
+	label: string;
+	nodeType: 'decoration';
+	decorationType: DecorationType;
+	inPorts: PortConfig[];
+	outPorts: PortConfig[];
+	description?: string;
+	isValid?: boolean;
+	validationErrors?: string[];
+	text?: string;
+	imagePath?: string;
+	orientation?: 'horizontal' | 'vertical';
+	fillColor?: string;
+	strokeColor?: string;
+	strokeWidth?: number;
+	fontSize?: number;
+	fontColor?: string;
+	opacity?: number;
+}
+
 // Combined type for any flow node data
-export type AnyNodeData = NetrunNodeData | SubgraphNodeData;
+export type AnyNodeData = NetrunNodeData | SubgraphNodeData | DecorationNodeData;
 
 // Use generic Node with AnyNodeData to avoid union type issues
 export type FlowNode = Node<AnyNodeData>;
 export type NetrunNode = Node<NetrunNodeData, 'netrunNode'>;
 export type SubgraphNode = Node<SubgraphNodeData, 'subgraphNode'>;
+export type DecorationNode = Node<DecorationNodeData, 'decorationNode'>;
 export type NetrunEdge = Edge;
 
 // Expanded subgraph child node ID helpers
@@ -352,7 +396,7 @@ export function redo() {
 }
 
 // Helper functions
-export function addNode(node: NetrunNode) {
+export function addNode(node: FlowNode) {
 	pushHistory();
 	const tab = get(activeTab);
 	if (!tab) return;
@@ -370,13 +414,13 @@ export function updateNode(id: string, updates: Partial<NetrunNode>) {
 	});
 }
 
-export function updateNodeData(id: string, dataUpdates: Partial<NetrunNodeData>) {
+export function updateNodeData(id: string, dataUpdates: Partial<AnyNodeData>) {
 	pushHistory();
 	const tab = get(activeTab);
 	if (!tab) return;
 	updateActiveTab({
 		nodes: tab.nodes.map(node =>
-			node.id === id ? { ...node, data: { ...node.data, ...dataUpdates } } : node
+			node.id === id ? { ...node, data: { ...node.data, ...dataUpdates } as AnyNodeData } : node
 		)
 	});
 }
@@ -391,7 +435,7 @@ export function updateNodeDataLive(id: string, dataUpdates: Partial<AnyNodeData>
 	if (!tab) return;
 	updateActiveTab({
 		nodes: tab.nodes.map(node =>
-			node.id === id ? { ...node, data: { ...node.data, ...dataUpdates } } : node
+			node.id === id ? { ...node, data: { ...node.data, ...dataUpdates } as AnyNodeData } : node
 		),
 		isDirty: true,
 	});
@@ -1048,6 +1092,12 @@ export function isValidConnection(connection: {
 	const tab = get(activeTab);
 	if (!tab) return false;
 
+	// Reject connections to/from decoration nodes
+	const visNodes = get(allVisibleNodes);
+	const srcNode = visNodes.find(n => n.id === connection.source);
+	const tgtNode = connection.target ? visNodes.find(n => n.id === connection.target) : null;
+	if (srcNode?.data.nodeType === 'decoration' || tgtNode?.data.nodeType === 'decoration') return false;
+
 	// Prevent cross-boundary connections involving expanded child nodes
 	const srcIsChild = isExpandedChildNode(connection.source);
 	const tgtIsChild = connection.target ? isExpandedChildNode(connection.target) : false;
@@ -1214,6 +1264,9 @@ export function updateGraphExtraLive(updates: Record<string, unknown>): void {
  * Validate a single node and return validation errors
  */
 function validateNode(node: FlowNode, allNodes: FlowNode[]): string[] {
+	// Decoration nodes don't need validation
+	if (node.data.nodeType === 'decoration') return [];
+
 	const errors: string[] = [];
 
 	// Check label
@@ -1356,14 +1409,15 @@ async function runBackendValidation(): Promise<BackendValidationResult> {
 	if (!tab) return { nodeErrorCount: 0, configErrors: [] };
 
 	try {
-		// Convert nodes to UINode format for API
-		const apiNodes: UINode[] = tab.nodes.map(n => ({
+		// Convert nodes to UINode format for API, excluding decoration nodes
+		const functionalNodes = tab.nodes.filter(n => n.data.nodeType !== 'decoration');
+		const apiNodes: UINode[] = functionalNodes.map(n => ({
 			id: n.id,
 			type: n.type || 'netrunNode',
 			position: n.position,
 			data: {
 				label: n.data.label,
-				nodeType: n.data.nodeType,
+				nodeType: n.data.nodeType as 'regular' | 'factory' | 'subgraph',
 				inPorts: n.data.inPorts,
 				outPorts: n.data.outPorts,
 				factory: (n.data as NetrunNodeData).factory,
@@ -1500,8 +1554,8 @@ activeTab.subscribe((tab) => {
 	if (!tab) return;
 
 	// Create a simple hash of nodes and edges to detect changes
-	// Only include fields that affect validation
-	const nodesForValidation = tab.nodes.map(n => ({
+	// Only include fields that affect validation (exclude decoration nodes)
+	const nodesForValidation = tab.nodes.filter(n => n.data.nodeType !== 'decoration').map(n => ({
 		id: n.id,
 		label: n.data.label,
 		nodeType: n.data.nodeType,
@@ -1717,6 +1771,82 @@ export function createFactoryNode(
 	};
 }
 
+// Check if a node is a decoration node
+export function isDecorationNode(node: FlowNode): node is DecorationNode {
+	return node.data.nodeType === 'decoration';
+}
+
+// Create a new decoration node
+export function createDecorationNode(
+	position: { x: number; y: number },
+	decorationType: DecorationType = 'rectangle',
+	name?: string,
+): DecorationNode {
+	const tab = get(activeTab);
+	const existingNodes = tab?.nodes || [];
+	const baseName = name || decorationType.charAt(0).toUpperCase() + decorationType.slice(1).replace('-', ' ');
+	const nodeName = generateUniqueNodeName(existingNodes, baseName);
+
+	const defaults: Partial<DecorationNodeData> = {};
+	let width = 150;
+	let height = 100;
+
+	if (decorationType === 'label') {
+		defaults.text = 'Label';
+		defaults.fontSize = 16;
+		width = 120;
+		height = 40;
+	} else if (decorationType === 'textbox') {
+		defaults.text = 'Text';
+		defaults.fontSize = 14;
+		defaults.fillColor = '#1f2937';
+		defaults.strokeColor = '#6b7280';
+		defaults.strokeWidth = 2;
+		width = 200;
+		height = 120;
+	} else if (decorationType === 'divider') {
+		defaults.strokeColor = '#6b7280';
+		defaults.strokeWidth = 2;
+		defaults.orientation = 'vertical';
+		width = 4;
+		height = 200;
+	} else if (decorationType === 'circle') {
+		defaults.fillColor = '#374151';
+		defaults.strokeColor = '#6b7280';
+		defaults.strokeWidth = 2;
+		width = 100;
+		height = 100;
+	} else if (decorationType === 'image') {
+		defaults.fillColor = '#1f2937';
+		defaults.strokeColor = '#6b7280';
+		defaults.strokeWidth = 2;
+		width = 150;
+		height = 150;
+	} else {
+		defaults.fillColor = '#374151';
+		defaults.strokeColor = '#6b7280';
+		defaults.strokeWidth = 2;
+	}
+
+	return {
+		id: nodeName,
+		type: 'decorationNode',
+		position,
+		width,
+		height,
+		zIndex: -1,
+		data: {
+			label: nodeName,
+			nodeType: 'decoration',
+			decorationType,
+			inPorts: [],
+			outPorts: [],
+			opacity: 1,
+			...defaults,
+		},
+	};
+}
+
 // Helper to convert API port info to our PortConfig
 function apiPortToPortConfig(port: { name: string; type?: string | null }): PortConfig {
 	return {
@@ -1784,6 +1914,50 @@ function convertApiEdges(apiEdges: UIEdge[]): NetrunEdge[] {
 	}));
 }
 
+/**
+ * Convert serialized decorations from graphExtra into FlowNode[] and strip them from graphExtra.
+ * Returns { decorationNodes, cleanedExtra }.
+ */
+function extractDecorations(extra: Record<string, unknown> | null): {
+	decorationNodes: FlowNode[];
+	cleanedExtra: Record<string, unknown> | null;
+} {
+	if (!extra || !Array.isArray(extra.decorations)) {
+		return { decorationNodes: [], cleanedExtra: extra };
+	}
+
+	const decorationNodes: FlowNode[] = (extra.decorations as Record<string, unknown>[]).map(d => ({
+		id: d.id as string,
+		type: 'decorationNode',
+		position: d.position as { x: number; y: number },
+		...(d.width != null ? { width: d.width as number } : {}),
+		...(d.height != null ? { height: d.height as number } : {}),
+		zIndex: -1,
+		data: {
+			label: (d.label as string) || (d.id as string),
+			nodeType: 'decoration' as const,
+			decorationType: (d.decorationType as DecorationType) || 'rectangle',
+			inPorts: [],
+			outPorts: [],
+			text: d.text as string | undefined,
+			imagePath: d.imagePath as string | undefined,
+			orientation: d.orientation as 'horizontal' | 'vertical' | undefined,
+			fillColor: d.fillColor as string | undefined,
+			strokeColor: d.strokeColor as string | undefined,
+			strokeWidth: d.strokeWidth as number | undefined,
+			fontSize: d.fontSize as number | undefined,
+			fontColor: d.fontColor as string | undefined,
+			opacity: (d.opacity as number) ?? 1,
+		},
+	}));
+
+	// Remove decorations key from graphExtra to avoid duplication
+	const { decorations: _removed, ...rest } = extra;
+	const cleanedExtra = Object.keys(rest).length > 0 ? rest : null;
+
+	return { decorationNodes, cleanedExtra };
+}
+
 // Load from file via API
 // Creates a new tab if file not already open, or switches to existing tab
 export async function loadFromFile(path: string): Promise<void> {
@@ -1799,6 +1973,10 @@ export async function loadFromFile(path: string): Promise<void> {
 	const loadedNodes = convertApiNodes(response.nodes);
 	const loadedEdges = convertApiEdges(response.edges);
 
+	// Extract decorations from graphExtra and merge into nodes
+	const { decorationNodes, cleanedExtra } = extractDecorations(response.extra || null);
+	const allNodes = [...loadedNodes, ...decorationNodes];
+
 	// Check if current tab is empty and untitled - reuse it
 	const currentTab = get(activeTab);
 	const currentTabList = get(tabs);
@@ -1808,24 +1986,24 @@ export async function loadFromFile(path: string): Promise<void> {
 		updateActiveTab({
 			filePath: path,
 			fileName: path.split('/').pop() || 'Untitled',
-			nodes: loadedNodes,
+			nodes: allNodes,
 			edges: loadedEdges,
 			isDirty: false,
 			history: { past: [], future: [] },
 			extraData: response.extra_data || null,
-			graphExtra: response.extra || null,
+			graphExtra: cleanedExtra,
 			fileFormat: response.format,
 		});
 	} else {
 		// Create a new tab with the loaded content
 		const tabId = createTab(path, true);
 		updateTab(tabId, {
-			nodes: loadedNodes,
+			nodes: allNodes,
 			edges: loadedEdges,
 			isDirty: false,
 			history: { past: [], future: [] },
 			extraData: response.extra_data || null,
-			graphExtra: response.extra || null,
+			graphExtra: cleanedExtra,
 			fileFormat: response.format,
 		});
 	}
@@ -1861,11 +2039,13 @@ export async function reloadFile(): Promise<void> {
 		}
 
 		const response = await api.readFile(tab.filePath);
+		const reloadedNodes = convertApiNodes(response.nodes);
+		const { decorationNodes, cleanedExtra } = extractDecorations(response.extra || null);
 		updateActiveTab({
-			nodes: convertApiNodes(response.nodes),
+			nodes: [...reloadedNodes, ...decorationNodes],
 			edges: convertApiEdges(response.edges),
 			extraData: response.extra_data || null,
-			graphExtra: response.extra || null,
+			graphExtra: cleanedExtra,
 			fileFormat: response.format,
 			isDirty: false,
 			history: { past: [], future: [] },
@@ -1898,10 +2078,11 @@ export function saveInlineSubgraphToParent(): boolean {
 	const parentNode = parentTab.nodes.find(n => n.id === nodeId);
 	if (!parentNode || parentNode.data.nodeType !== 'subgraph') return false;
 
-	// Build the updated subgraph config from current tab's nodes/edges
+	// Build the updated subgraph config from current tab's nodes/edges (exclude decorations)
+	const subgraphNodes = tab.nodes.filter(n => n.data.nodeType !== 'decoration');
 	const updatedConfig = {
 		...(parentNode.data as SubgraphNodeData)._subgraphConfig,
-		nodes: tab.nodes.map(n => {
+		nodes: subgraphNodes.map(n => {
 			// Convert UI node back to config format
 			const nodeData = n.data;
 
@@ -1952,7 +2133,7 @@ export function saveInlineSubgraphToParent(): boolean {
 				...n,
 				data: {
 					...n.data,
-					nodeCount: tab.nodes.length,
+					nodeCount: subgraphNodes.length,
 					_subgraphConfig: updatedConfig,
 				}
 			};
@@ -1986,9 +2167,9 @@ export async function saveToFile(path?: string): Promise<void> {
 		throw new Error('Failed to save inline subgraph to parent');
 	}
 
-	// Check for duplicate node names before saving
+	// Check for duplicate node names before saving (only functional nodes)
 	const nameCount = new Map<string, number>();
-	for (const node of tab.nodes) {
+	for (const node of tab.nodes.filter(n => n.data.nodeType !== 'decoration')) {
 		const name = node.data.label.trim();
 		nameCount.set(name, (nameCount.get(name) || 0) + 1);
 	}
@@ -2016,8 +2197,34 @@ export async function saveToFile(path?: string): Promise<void> {
 		format = 'toml';
 	}
 
+	// Separate decoration nodes from functional nodes
+	const functionalNodes = tab.nodes.filter(n => n.data.nodeType !== 'decoration');
+	const decorationNodes = tab.nodes.filter(n => n.data.nodeType === 'decoration');
+
+	// Serialize decorations for graphExtra
+	const serializedDecorations = decorationNodes.map(n => {
+		const d = n.data as DecorationNodeData;
+		return {
+			id: n.id,
+			position: n.position,
+			...(n.width != null ? { width: n.width } : {}),
+			...(n.height != null ? { height: n.height } : {}),
+			decorationType: d.decorationType,
+			label: d.label,
+			...(d.text ? { text: d.text } : {}),
+			...(d.imagePath ? { imagePath: d.imagePath } : {}),
+			...(d.orientation ? { orientation: d.orientation } : {}),
+			...(d.fillColor ? { fillColor: d.fillColor } : {}),
+			...(d.strokeColor ? { strokeColor: d.strokeColor } : {}),
+			...(d.strokeWidth != null ? { strokeWidth: d.strokeWidth } : {}),
+			...(d.fontSize != null ? { fontSize: d.fontSize } : {}),
+			...(d.fontColor ? { fontColor: d.fontColor } : {}),
+			...(d.opacity != null && d.opacity !== 1 ? { opacity: d.opacity } : {}),
+		};
+	});
+
 	// Convert to API format
-	const apiNodes: UINode[] = tab.nodes.map(node => {
+	const apiNodes: UINode[] = functionalNodes.map(node => {
 		const data = node.data as NetrunNodeData | SubgraphNodeData;
 		const baseData = {
 			label: data.label,
@@ -2086,12 +2293,20 @@ export async function saveToFile(path?: string): Promise<void> {
 		type: edge.type,
 	}));
 
+	// Build graphExtra with decorations
+	const graphExtraForSave: Record<string, unknown> = { ...(tab.graphExtra || {}) };
+	if (serializedDecorations.length > 0) {
+		graphExtraForSave.decorations = serializedDecorations;
+	} else {
+		delete graphExtraForSave.decorations;
+	}
+
 	await api.saveFile(
 		savePath,
 		format,
 		apiNodes,
 		apiEdges,
-		tab.graphExtra ?? undefined,
+		Object.keys(graphExtraForSave).length > 0 ? graphExtraForSave : undefined,
 		tab.extraData ?? undefined
 	);
 
@@ -2209,14 +2424,14 @@ export async function createSubgraphFromSelection(subgraphName: string): Promise
 		return false;
 	}
 
-	// Get selected nodes and all edges
-	const selectedNodes = tab.nodes.filter(n => selectedIds.has(n.id));
+	// Get selected nodes (exclude decorations) and all edges
+	const selectedNodes = tab.nodes.filter(n => selectedIds.has(n.id) && n.data.nodeType !== 'decoration');
 
 	// Convert nodes to API format
 	const apiNodes: UINode[] = selectedNodes.map(node => {
 		const baseData = {
 			label: node.data.label,
-			nodeType: node.data.nodeType,
+			nodeType: node.data.nodeType as 'regular' | 'factory' | 'subgraph',
 			inPorts: node.data.inPorts,
 			outPorts: node.data.outPorts,
 			isValid: node.data.isValid,
@@ -2253,11 +2468,12 @@ export async function createSubgraphFromSelection(subgraphName: string): Promise
 		}
 	});
 
-	// Convert all nodes to API format
-	const allApiNodes: UINode[] = tab.nodes.map(node => {
+	// Convert all nodes to API format (exclude decorations)
+	const allFunctionalNodes = tab.nodes.filter(n => n.data.nodeType !== 'decoration');
+	const allApiNodes: UINode[] = allFunctionalNodes.map(node => {
 		const baseData = {
 			label: node.data.label,
-			nodeType: node.data.nodeType,
+			nodeType: node.data.nodeType as 'regular' | 'factory' | 'subgraph',
 			inPorts: node.data.inPorts,
 			outPorts: node.data.outPorts,
 			isValid: node.data.isValid,
@@ -2541,9 +2757,10 @@ registerBeforeTabSwitchHandler((fromTab: TabState) => {
 		const parentNode = parentTab.nodes.find(n => n.id === nodeId);
 		if (!parentNode || parentNode.data.nodeType !== 'subgraph') return;
 
+		const tabSubgraphNodes = fromTab.nodes.filter(n => n.data.nodeType !== 'decoration');
 		const updatedConfig = {
 			...(parentNode.data as SubgraphNodeData)._subgraphConfig,
-			nodes: fromTab.nodes.map(n => {
+			nodes: tabSubgraphNodes.map(n => {
 				const nodeData = n.data;
 				if (nodeData.nodeType === 'subgraph') {
 					const subgraphData = nodeData as SubgraphNodeData;
@@ -2579,7 +2796,7 @@ registerBeforeTabSwitchHandler((fromTab: TabState) => {
 					...n,
 					data: {
 						...n.data,
-						nodeCount: fromTab.nodes.length,
+						nodeCount: tabSubgraphNodes.length,
 						_subgraphConfig: updatedConfig,
 					}
 				};

--- a/netrun-ui/src/lib/stores/subgraphExpandStore.ts
+++ b/netrun-ui/src/lib/stores/subgraphExpandStore.ts
@@ -985,7 +985,7 @@ function handleChildNodeDataUpdate(childNodeId: string, dataUpdates: Partial<Any
 	if (cached) {
 		cached.nodes = cached.nodes.map(n => {
 			if (n.id !== originalId) return n;
-			return { ...n, data: { ...n.data, ...dataUpdates } };
+			return { ...n, data: { ...n.data, ...dataUpdates } as AnyNodeData };
 		});
 		markCacheDirty(tabId, parentId);
 	}
@@ -1132,10 +1132,10 @@ function flowNodeToUINode(node: FlowNode): UINode {
 		...(node.height != null ? { height: node.height } : {}),
 		data: {
 			label: data.label,
-			nodeType: data.nodeType,
+			nodeType: data.nodeType as 'regular' | 'factory' | 'subgraph',
 			inPorts: data.inPorts.map(p => ({ name: p.name, type: p.type })),
 			outPorts: data.outPorts.map(p => ({ name: p.name, type: p.type })),
-			description: data.description,
+			description: data.description as string | undefined,
 			_config: (data as Record<string, unknown>)._config as Record<string, unknown> | undefined,
 		},
 	};

--- a/netrun-ui/src/lib/utils/autoLayout.ts
+++ b/netrun-ui/src/lib/utils/autoLayout.ts
@@ -90,8 +90,13 @@ export async function computeLayout(
 
 	const isHorizontal = algorithm.elkDirection === 'RIGHT' || algorithm.elkDirection === 'LEFT';
 
+	// Filter out decoration nodes — they should not participate in layout
+	const layoutNodes = nodes.filter(
+		(n) => (n.data as Record<string, unknown>)?.nodeType !== 'decoration'
+	);
+
 	// Build ELK graph
-	const elkNodes: ElkNode[] = nodes.map((node) => {
+	const elkNodes: ElkNode[] = layoutNodes.map((node) => {
 		const dims = nodeDimensions?.get(node.id);
 		const width = dims?.width ?? DEFAULT_WIDTH;
 		const height = dims?.height ?? DEFAULT_HEIGHT;


### PR DESCRIPTION
## Summary
- Add non-functional visual decoration nodes (rectangle, rounded rectangle, circle, triangle, divider, label, textbox, image) for annotating flow diagrams
- Decorations are serialized in `graphExtra.decorations`, filtered from validation/layout/backend processing
- Two-row toolbar layout, sidebar properties panel with color/opacity/orientation controls, command palette integration, and backend image serving endpoint

## Test plan
- [ ] Create each decoration type via toolbar dropdown and command palette
- [ ] Verify shapes render correctly, are draggable/resizable, and have no connection handles
- [ ] Edit properties (colors, text, opacity, orientation) in sidebar
- [ ] Save/reload file and verify decorations persist in `graphExtra.decorations`
- [ ] Test undo/redo, copy/paste, auto-layout exclusion
- [ ] Verify divider horizontal/vertical toggle swaps dimensions
- [ ] Verify textbox supports multiline text entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)